### PR TITLE
fix: eliminate gallery layout shift via server-side metadata

### DIFF
--- a/apps/harrychang-me/app/(main)/page.tsx
+++ b/apps/harrychang-me/app/(main)/page.tsx
@@ -3,6 +3,7 @@ import AboutSection from "@portfolio/ui/about-section"
 import UpdatesSection from "@portfolio/ui/updates-section"
 import ProjectsSection from "@portfolio/ui/projects-section"
 import GallerySection from "@portfolio/ui/gallery-section"
+import { getAllGalleryMetadata } from "@portfolio/lib/lib/markdown"
 
 export const metadata: Metadata = {
   title: "Harry Chang 張祺煒 | Portfolio",
@@ -17,12 +18,15 @@ export const metadata: Metadata = {
 }
 
 export default function Home() {
+  // Fetch gallery items at build/request time - dimensions available immediately
+  const galleryItems = getAllGalleryMetadata('en')
+
   return (
     <>
       <AboutSection />
       <UpdatesSection />
       <ProjectsSection />
-      <GallerySection />
+      <GallerySection initialItems={galleryItems} />
     </>
   )
 }

--- a/packages/ui/gallery-card.tsx
+++ b/packages/ui/gallery-card.tsx
@@ -56,7 +56,8 @@ export default function GalleryCard({
     rootMargin: '50px'
   })
   const [imageLoaded, setImageLoaded] = useState(false)
-  const [blurComplete, setBlurComplete] = useState(false)
+  const [thumbLoaded, setThumbLoaded] = useState(false)
+  const [fullLoaded, setFullLoaded] = useState(false)
 
   // If we have width/height, calculate aspect ratio immediately to prevent CLS
   const haveDims = !!width && !!height
@@ -180,39 +181,44 @@ export default function GalleryCard({
               <div className="absolute inset-0 w-full h-full">
                 {shouldLoad && (
                   <>
+                    {/* Thumbnail: Always loads first with priority */}
                     {thumbnailSrc && (
                       <Image
                         src={thumbnailSrc}
                         alt={title}
                         fill
-                        className={`transition-all duration-700 ease-in-out group-hover:brightness-95 ${
-                          (haveDims ? constrained.isPortrait : isPortrait) && 
+                        className={`transition-all duration-500 ease-out group-hover:brightness-95 ${
+                          (haveDims ? constrained.isPortrait : isPortrait) &&
                           (haveDims ? (width! / height!) < 0.8 : originalAspect < 0.8) ||
-                          (!haveDims ? !isPortrait : !constrained.isPortrait) && 
+                          (!haveDims ? !isPortrait : !constrained.isPortrait) &&
                           (haveDims ? (width! / height!) > 1.25 : originalAspect > 1.25)
                             ? "object-contain" : "object-cover"
-                        } object-center ${blurComplete ? 'opacity-0' : 'opacity-100'}`}
+                        } object-center ${fullLoaded ? 'opacity-0' : 'opacity-100'}`}
                         sizes={thumbnailSizes}
                         quality={20}
+                        priority={priority || index < 6}
+                        onLoad={() => setThumbLoaded(true)}
                       />
                     )}
-                    
-                    <Image
-                      src={fullImageUrl || "/placeholder.svg"}
-                      alt={title}
-                      fill
-                      className={`transition-all duration-700 ease-in-out group-hover:brightness-95 ${
-                        (haveDims ? constrained.isPortrait : isPortrait) && 
-                        (haveDims ? (width! / height!) < 0.8 : originalAspect < 0.8) ||
-                        (!haveDims ? !isPortrait : !constrained.isPortrait) && 
-                        (haveDims ? (width! / height!) > 1.25 : originalAspect > 1.25)
-                          ? "object-contain" : "object-cover"
-                      } object-center ${blurComplete ? 'opacity-100' : 'opacity-0'}`}
-                      sizes={fullImageSizes}
-                      priority={priority || index < 3}
-                      quality={70}
-                      onLoad={() => setBlurComplete(true)}
-                    />
+
+                    {/* Full: Only start loading after thumbnail is ready */}
+                    {thumbLoaded && (
+                      <Image
+                        src={fullImageUrl || "/placeholder.svg"}
+                        alt={title}
+                        fill
+                        className={`transition-all duration-700 ease-in-out group-hover:brightness-95 ${
+                          (haveDims ? constrained.isPortrait : isPortrait) &&
+                          (haveDims ? (width! / height!) < 0.8 : originalAspect < 0.8) ||
+                          (!haveDims ? !isPortrait : !constrained.isPortrait) &&
+                          (haveDims ? (width! / height!) > 1.25 : originalAspect > 1.25)
+                            ? "object-contain" : "object-cover"
+                        } object-center ${fullLoaded ? 'opacity-100' : 'opacity-0'}`}
+                        sizes={fullImageSizes}
+                        quality={70}
+                        onLoad={() => setFullLoaded(true)}
+                      />
+                    )}
                   </>
                 )}
               </div>

--- a/packages/ui/staggered-menu.tsx
+++ b/packages/ui/staggered-menu.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useLayoutEffect, useRef, useState, useEffect } from
 import { gsap } from 'gsap';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useLanguage } from "@portfolio/lib/contexts/LanguageContext"
-import Link from "next/link"
+import NavigationLink from "@portfolio/ui/navigation-link"
 import { usePathname } from "next/navigation"
 
 export interface StaggeredMenuItem {
@@ -426,7 +426,7 @@ export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
                 items.map((it, idx) => (
                   <li className="sm-panel-itemWrap relative overflow-hidden leading-none" key={it.label + idx}>
                     <motion.div whileHover={{ y: -2 }} transition={{ duration: 0.2 }}>
-                      <Link
+                      <NavigationLink
                         className="sm-panel-item relative text-foreground font-heading font-semibold text-[3rem] md:text-[4rem] cursor-pointer leading-none tracking-[-2px] uppercase transition-[background,color] duration-150 ease-linear inline-block no-underline pr-[1.4em] hover:text-[var(--sm-accent)]"
                         href={it.link}
                         aria-label={it.ariaLabel}
@@ -439,7 +439,7 @@ export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
                             {String(idx + 1)}
                           </span>
                         </span>
-                      </Link>
+                      </NavigationLink>
                     </motion.div>
                   </li>
                 ))


### PR DESCRIPTION

<img width="2055" height="1184" alt="Screenshot 2025-11-29 at 20 36 02" src="https://github.com/user-attachments/assets/ebbeb216-127a-4cc5-888f-0924f4eddd80" />


### Summary
This PR addresses the critical Cumulative Layout Shift (CLS) issue (0.761) identified in [Issue #10](https://github.com/Harrychangtw/portfolio-monorepo/issues/10).

By implementing **Option B (Server Component data fetching)**, we have moved the initial gallery metadata retrieval from a client-side API call to the server-side build/request time. This allows gallery cards to render with their correct aspect ratios immediately upon HTML arrival, eliminating the "snap" effect and significantly improving the Core Web Vitals score.

### Key Changes

**1. Architecture & Performance**
*   **Server-Side Data Injection:** `page.tsx` now fetches gallery metadata using `getAllGalleryMetadata` during the server render pass and feeds it into the `GallerySection`.
*   **CLS Elimination:** Since dimensions (`width`/`height`) are available in the initial HTML, the browser reserves the correct space for images before they load, preventing layout shifts.
*   **Optimized Image Loading Strategy:** Refactored `GalleryCard` to prioritize loading thumbnails (low-res) first. The high-res image only begins loading once the thumbnail is ready, reducing bandwidth contention during the critical initial render.

**2. Component Updates**
*   **GallerySection:** Updated to accept an optional `initialItems` prop. The internal `useEffect` fetch is now skipped if initial data is provided (specifically for the default 'en' locale).
*   **GalleryCard:** Replaced the previous blur logic with a two-stage opacity transition (Thumbnail → Full Image) for a smoother visual experience.
*   **StaggeredMenu:** Minor fix to replace standard `Link` with the custom `NavigationLink` component, ensuring the global navigation progress bar works consistently across the menu (aligning with PR #7).

### Technical Details
*   **Files Modified:**
    *   `apps/harrychang-me/app/(main)/page.tsx`: Injects server-side data.
    *   `packages/ui/gallery-section.tsx`: Handles hybrid data sources (props vs. API).
    *   `packages/ui/gallery-card.tsx`: Implemented priority loading for thumbnails.
    *   `packages/ui/staggered-menu.tsx`: Integrated `NavigationLink`.

### Closes
Closes #10