### PR TITLE
fix: resolve mobile menu freeze caused by GSAP splitColor crash

### DIFF
--- a/apps/harrychang-me/components/staggered-menu.tsx
+++ b/apps/harrychang-me/components/staggered-menu.tsx
@@ -336,14 +336,12 @@ export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
       colorTweenRef.current?.kill();
       if (changeMenuColorOnOpen) {
         const targetColor = opening ? openMenuButtonColor : menuButtonColor;
-        colorTweenRef.current = gsap.to(btn, {
-          color: targetColor,
-          delay: 0.18,
-          duration: 0.3,
-          ease: "power2.out",
-        });
+        // Use CSS transition instead of GSAP — GSAP cannot parse CSS var() syntax
+        // which causes a splitColor TypeError that crashes the ticker
+        btn.style.transition = "color 0.3s ease-out 0.18s";
+        btn.style.color = targetColor;
       } else {
-        gsap.set(btn, { color: menuButtonColor });
+        btn.style.color = menuButtonColor;
       }
     },
     [openMenuButtonColor, menuButtonColor, changeMenuColorOnOpen],

--- a/apps/harrychang-me/components/staggered-menu.tsx
+++ b/apps/harrychang-me/components/staggered-menu.tsx
@@ -341,6 +341,7 @@ export const StaggeredMenu: React.FC<StaggeredMenuProps> = ({
         btn.style.transition = "color 0.3s ease-out 0.18s";
         btn.style.color = targetColor;
       } else {
+        btn.style.transition = "";
         btn.style.color = menuButtonColor;
       }
     },


### PR DESCRIPTION
## Summary

- **Root cause:** `animateColor()` passed CSS variable values (`hsl(var(--foreground))`) to `gsap.to()`. GSAP's `splitColor` cannot parse `var()` syntax, throwing `TypeError: Cannot read properties of null (reading 'map')`. This unhandled error crashed GSAP's rAF ticker, killing all subsequent animations including the panel slide — making the mobile menu appear frozen.
- **Why it surfaced after `/graph` navigation:** The crash happens during the ticker's `updateRoot` cycle when the delayed color tween initializes (0.18s after creation). After navigating through `/graph` and back, orphaned animations from unmounted `StaggeredMenu` instances leave the ticker in a fragile state where the `splitColor` crash permanently kills it.
- **Fix:** Replace GSAP color tweening with native CSS `transition` property, which handles `var()` syntax natively. Same visual timing preserved (0.3s ease-out, 0.18s delay).

Closes #49

## Test plan

- [x] Reproduce: home → open menu → click Graph → open/close menu on graph → click "Harry Chang" → open menu on home — menu now works
- [x] Open/close cycle works correctly (panel slides in/out, body scroll locks/unlocks)
- [x] No GSAP `splitColor` errors in console
- [x] TypeScript passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized menu toggle button text color animation for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->