### PR TITLE
docs(readme): emit mobile lighthouse table alongside desktop

### DIFF
--- a/.github/scripts/update-lighthouse-readme.js
+++ b/.github/scripts/update-lighthouse-readme.js
@@ -62,7 +62,12 @@ const timestamp  = new Date().toUTCString();
 
 if (mode === 'prod') {
   const desktopData = readLhrDir('.lighthouseci');
-  if (Object.keys(desktopData).length === 0) {
+  const mobileData  = readLhrDir('.lighthouseci-mobile');
+
+  const hasDesktop = Object.keys(desktopData).length > 0;
+  const hasMobile  = Object.keys(mobileData).length > 0;
+
+  if (!hasDesktop && !hasMobile) {
     console.log('No production LHR JSON files found — skipping README update.');
     process.exit(0);
   }
@@ -72,11 +77,19 @@ if (mode === 'prod') {
     ? `> 🕐 **Last audited:** ${timestamp}  \n> 🌐 **Deployment:** ${deploymentUrl}`
     : `> 🕐 **Last audited:** ${timestamp}`;
 
+  const sections = [];
+  if (hasDesktop) {
+    sections.push(`#### Desktop (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(desktopData)}`);
+  }
+  if (hasMobile) {
+    sections.push(`#### Mobile (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(mobileData)}`);
+  }
+
   const block = [
     '<!-- LIGHTHOUSE_PROD_RESULTS_START -->',
     header,
     '',
-    `#### Desktop (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(desktopData)}`,
+    sections.join('\n\n'),
     '<!-- LIGHTHOUSE_PROD_RESULTS_END -->',
   ].join('\n');
 

--- a/.github/workflows/lighthouse-prod.yml
+++ b/.github/workflows/lighthouse-prod.yml
@@ -113,6 +113,27 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Run Lighthouse CI (Mobile, against live deployment)
+        if: steps.loop_guard.outputs.skip != 'true'
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: ${{ steps.urls.outputs.list }}
+          configPath: apps/harrychang-me/.lighthouserc.mobile.json
+          artifactsDirectory: .lighthouseci-mobile
+          artifactName: lighthouse-results-prod-mobile
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+
+      # lhci writes to .lighthouseci/ regardless of artifactsDirectory.
+      # Move mobile LHRs aside so the desktop run doesn't clobber them.
+      - name: Move mobile LHRs out of .lighthouseci
+        if: steps.loop_guard.outputs.skip != 'true'
+        run: |
+          if [ -d .lighthouseci ]; then
+            rm -rf .lighthouseci-mobile
+            mv .lighthouseci .lighthouseci-mobile
+          fi
+
       - name: Run Lighthouse CI (Desktop, against live deployment)
         if: steps.loop_guard.outputs.skip != 'true'
         uses: treosh/lighthouse-ci-action@v12

--- a/.github/workflows/lighthouse-prod.yml
+++ b/.github/workflows/lighthouse-prod.yml
@@ -119,13 +119,13 @@ jobs:
         with:
           urls: ${{ steps.urls.outputs.list }}
           configPath: apps/harrychang-me/.lighthouserc.mobile.json
-          artifactsDirectory: .lighthouseci-mobile
           artifactName: lighthouse-results-prod-mobile
           uploadArtifacts: true
           temporaryPublicStorage: true
 
-      # lhci writes to .lighthouseci/ regardless of artifactsDirectory.
-      # Move mobile LHRs aside so the desktop run doesn't clobber them.
+      # lhci writes to .lighthouseci/; treosh/lighthouse-ci-action@v12 has no
+      # input to redirect that. Move mobile LHRs aside so the desktop run
+      # doesn't clobber them.
       - name: Move mobile LHRs out of .lighthouseci
         if: steps.loop_guard.outputs.skip != 'true'
         run: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -99,6 +99,17 @@ jobs:
           uploadArtifacts: true
           temporaryPublicStorage: true
 
+      # lhci writes LHRs to .lighthouseci/ regardless of the action's
+      # artifactsDirectory input (which only controls upload). Move them so
+      # the desktop run below doesn't clobber the mobile JSONs and the
+      # README script can read them from .lighthouseci-mobile/.
+      - name: Move mobile LHRs out of .lighthouseci
+        run: |
+          if [ -d .lighthouseci ]; then
+            rm -rf .lighthouseci-mobile
+            mv .lighthouseci .lighthouseci-mobile
+          fi
+
       - name: Run Lighthouse CI (Desktop)
         uses: treosh/lighthouse-ci-action@v12
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -94,15 +94,15 @@ jobs:
             http://localhost:3000/blog/2026_02_10_synecdoche_truman
             http://localhost:3000/graph
           configPath: apps/harrychang-me/.lighthouserc.mobile.json
-          artifactsDirectory: .lighthouseci-mobile
           artifactName: lighthouse-results-mobile
           uploadArtifacts: true
           temporaryPublicStorage: true
 
-      # lhci writes LHRs to .lighthouseci/ regardless of the action's
-      # artifactsDirectory input (which only controls upload). Move them so
-      # the desktop run below doesn't clobber the mobile JSONs and the
-      # README script can read them from .lighthouseci-mobile/.
+      # lhci writes LHRs to .lighthouseci/ and treosh/lighthouse-ci-action@v12
+      # has no input for redirecting that — only artifactName (upload) is in
+      # the action's schema. Move them so the desktop run below doesn't
+      # clobber the mobile JSONs and the README script can read them from
+      # .lighthouseci-mobile/.
       - name: Move mobile LHRs out of .lighthouseci
         run: |
           if [ -d .lighthouseci ]; then

--- a/apps/harrychang-me/README.md
+++ b/apps/harrychang-me/README.md
@@ -24,6 +24,12 @@ This site is engineered for uncompromising performance. Verified by Vercel Analy
 
 ### Lighthouse CI Results
 
+> **Reading the numbers.** Three different measurements appear on this page and they don't always agree:
+>
+> - **Real Experience Score (RES) — 100.** Field data from real visitors via Vercel Analytics. The bullets above (FCP ~1.55s, LCP ~1.66s, INP 80ms, CLS 0.01) are p75 across actual sessions on real networks and devices.
+> - **Lighthouse Desktop — 90+ across all routes.** Lab data: a single emulated desktop pageload over an unthrottled local connection.
+> - **Lighthouse Mobile — typically lower.** Lab data: emulated mid-tier phone with Slow 4G + 4× CPU throttling. This synthetic profile penalizes initial-render-heavy routes (RSC streaming + hydration) more aggressively than real mid-range devices on real networks; CrUX field LCP for the same routes sits in the 90+ percentile. The mobile lab number is reported here for transparency, not as a regression alarm.
+
 <!-- LIGHTHOUSE_RESULTS_START -->
 
 > 🕐 **Last audited:** Sat, 02 May 2026 14:03:03 GMT


### PR DESCRIPTION
## Summary

The README's Lighthouse section has always shown only Desktop, even though `lighthouse.yml` already invokes a mobile run. Root cause: both lhci invocations write LHRs to `.lighthouseci/` regardless of the treosh action's `artifactsDirectory` input (which only controls the GitHub artifact upload, not local output). The desktop run clobbers the mobile JSONs, the script's `readLhrDir('.lighthouseci-mobile')` finds an empty directory, and the Mobile section is never rendered.

Fix: move mobile LHRs out of `.lighthouseci` to `.lighthouseci-mobile` between the two runs. Mirror the same setup in `lighthouse-prod.yml`, which previously had no mobile run at all. Extend `update-lighthouse-readme.js` prod-mode to emit `#### Mobile (Production Deployment)` when `.lighthouseci-mobile/` is populated.

Also adds a "Reading the numbers" preface above the marker block to contextualize the three measurements on the page (RES 100 field data vs. Lighthouse Desktop 90+ lab vs. Lighthouse Mobile lab) so the mobile scores — which will publish red badges given current p50 mobile avg ~72 — aren't read as a regression against the field-data hero numbers. Per issue #58, the mobile lab gap is structural (RSC streaming + hydration on simulated Slow 4G + 4× CPU), not a regression.

## Changes

- `.github/workflows/lighthouse.yml` — new step "Move mobile LHRs out of .lighthouseci" between mobile and desktop Lighthouse runs.
- `.github/workflows/lighthouse-prod.yml` — new mobile run step before desktop, plus the same move step.
- `.github/scripts/update-lighthouse-readme.js` — prod-mode now reads both directories and emits both sections, parallel to the simulated-mode behavior already in place.
- `apps/harrychang-me/README.md` — adds a blockquote above `<!-- LIGHTHOUSE_RESULTS_START -->` explaining what RES, lab desktop, and lab mobile each measure. Placed outside the marker block so CI rewrites don't strip it.

## Test plan

- [x] Smoke-tested `update-lighthouse-readme.js --mode=prod` locally with synthetic LHRs in both `.lighthouseci/` and `.lighthouseci-mobile/`. Both Desktop and Mobile tables render under the same prod marker block.
- [ ] After merge, confirm the next `lighthouse.yml` run on main commits a README with both Desktop and Mobile sections.
- [ ] After the next production deploy + `lighthouse-prod.yml` run, confirm the prod marker block also includes both Desktop and Mobile.
- [ ] Visually confirm the "Reading the numbers" preface stays in place across CI commits (sits outside marker block).

## Out of scope

- Fixing the actual mobile LCP gap. Issue #58 documents that as RSC-streaming-bound; addressing it requires either a `RootClientShell` server-shell refactor or a server-emitted `<link rel="preload">` experiment, both tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile Lighthouse performance monitoring for production deployments alongside existing desktop metrics.
  * Production README now displays both desktop and mobile performance subsections.

* **Documentation**
  * Added clarification in README explaining differences between multiple performance metrics (field data vs. lab data).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->