### PR TITLE
fix(ui): forward priority prop and stop hardcoding it false on post heroes

### DIFF
--- a/packages/ui/blog-post-client.tsx
+++ b/packages/ui/blog-post-client.tsx
@@ -193,7 +193,7 @@ export default function BlogPostClient({
             <ImageContainer
               src={post.imageUrl}
               alt={post.title}
-              priority={false}
+              priority={true}
               quality={95}
               noInsetPadding={true}
               aspectRatio={1.5}

--- a/packages/ui/gallery-post-client.tsx
+++ b/packages/ui/gallery-post-client.tsx
@@ -155,7 +155,7 @@ export default function GalleryPostClient({
             <ImageContainer
               src={fullImageUrl}
               alt={item.title}
-              priority={false}
+              priority={true}
               quality={90}
               aspectRatio={item.aspectRatio}
               noInsetPadding={true}

--- a/packages/ui/image-container.tsx
+++ b/packages/ui/image-container.tsx
@@ -209,6 +209,7 @@ export function ImageContainer({
                       src={fullSrc}
                       alt={alt}
                       fill
+                      priority={priority}
                       className={`${noInsetPadding ? "object-cover" : "object-contain"} object-center transition-opacity duration-500 ${
                         blurComplete ? "opacity-100" : "opacity-0"
                       } ${imgClassName || ""}`}

--- a/packages/ui/project-post-client.tsx
+++ b/packages/ui/project-post-client.tsx
@@ -152,7 +152,7 @@ export default function ProjectPostClient({
             <ImageContainer
               src={project.imageUrl}
               alt={project.title}
-              priority={false}
+              priority={true}
               quality={95}
               noInsetPadding={true}
               aspectRatio={1.5}


### PR DESCRIPTION
## Summary

Two correctness bugs in the hero-image plumbing across blog/project/gallery post pages, both diagnosed in issue #58 as F1 and F2.

**F1 — `ImageContainer` never forwarded `priority` to `<Image>`.** The component declared the prop and used it for its IntersectionObserver gate, but the inner `next/image` element never received it. Every caller passing `priority={true}` was silently downgraded to the default `loading="lazy"` with no `fetchpriority` hint.

**F2 — Hero call-sites hardcode `priority={false}`.** Even after F1 is fixed, the literal `false` on `blog-post-client.tsx:196`, `project-post-client.tsx:155`, and `gallery-post-client.tsx:158` would still opt out. The non-hero `.map()` gallery image at `gallery-post-client.tsx:327` is intentionally left at `false`.

## ⚠️ This does not move synthetic Lighthouse mobile LCP

Per issue #58: the hero `<Image>` is rendered through a `"use client"` `RootClientShell`, so children stream as RSC and never appear in initial SSR HTML. There's no server-rendered `<img>` for `next/image`'s priority semantics to act on at SSR time, regardless of what the prop says.

This PR is shipped as a **correctness fix only** — the prop now does what the type signature claims, and any future preload-in-head experiment (issue #58 Option 2) that depends on `priority` actually reaching `<Image>` is no longer blocked.

## Changes

- `packages/ui/image-container.tsx` — adds `priority={priority}` on the inner `<Image>`.
- `packages/ui/blog-post-client.tsx` — hero `priority={false}` → `priority={true}`.
- `packages/ui/project-post-client.tsx` — hero `priority={false}` → `priority={true}`.
- `packages/ui/gallery-post-client.tsx` — hero `priority={false}` → `priority={true}`. Non-hero `.map()` images left untouched.

## Test plan

- [ ] Typecheck clean (`pnpm typecheck`).
- [ ] Lint clean (`pnpm lint`).
- [ ] Visual smoke: hero images on `/blog/[slug]`, `/projects/[slug]`, `/gallery/[slug]` still render with the existing blur-up + IntersectionObserver UX (no double-load, no flicker).
- [ ] Confirm no regression in non-hero card/gallery image loading behavior.
- [ ] **Not expecting** synthetic Lighthouse mobile LCP movement — see explanation above. CrUX field LCP and desktop scores should be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)