### PR TITLE
feat(ui): split-flap language-switch transition

### DIFF
--- a/packages/lib/contexts/language-context.tsx
+++ b/packages/lib/contexts/language-context.tsx
@@ -18,6 +18,10 @@ interface LanguageContextType {
   tHtml: (key: string, namespace?: string) => React.ReactNode;
   getTranslationData: (key: string, namespace?: string) => any;
   isLoading: boolean;
+  // Increments once per user-initiated language switch, after new translations
+  // have loaded. Consumers (e.g. <SplitFlap>) use this as a single trigger so
+  // every text node animates from the same event rather than each prop change.
+  transitionTick: number;
 }
 
 const LanguageContext = createContext<LanguageContextType | undefined>(
@@ -115,6 +119,8 @@ export function LanguageProvider({
   const [isLoading, setIsLoading] = useState(true);
   // Track if we've completed the first load
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const [transitionTick, setTransitionTick] = useState(0);
+  const pendingTransitionRef = React.useRef(false);
 
   // Load translations for a specific language
   const loadTranslations = async (lang: Language) => {
@@ -148,6 +154,11 @@ export function LanguageProvider({
 
       setTranslations(newTranslations);
       setHasLoadedOnce(true); // First load finished
+      // Only fire the flap transition for explicit switches, not the initial load.
+      if (pendingTransitionRef.current) {
+        pendingTransitionRef.current = false;
+        setTransitionTick((n) => n + 1);
+      }
     } catch (error) {
       console.error("Failed to load translations:", error);
       // Even on error, mark as loaded to prevent infinite hidden state
@@ -223,6 +234,7 @@ export function LanguageProvider({
       // In English-only mode, prevent language changes
       return;
     }
+    if (lang !== language) pendingTransitionRef.current = true;
     setLanguageState(lang);
     setCookie("language", lang);
   };
@@ -237,6 +249,7 @@ export function LanguageProvider({
         tHtml,
         getTranslationData,
         isLoading,
+        transitionTick,
       }}
     >
       {!hasLoadedOnce ? (

--- a/packages/ui/blog-section.tsx
+++ b/packages/ui/blog-section.tsx
@@ -6,6 +6,7 @@ import { PostMetadata } from "@portfolio/lib/lib/markdown";
 import { useIntersectionObserver } from "@portfolio/lib/hooks/use-intersection-observer";
 import { useLanguage } from "@portfolio/lib/contexts/language-context";
 import NavigationLink from "@portfolio/ui/navigation-link";
+import { SplitFlap } from "@portfolio/ui/split-flap";
 import { motion } from "framer-motion";
 
 interface BlogSectionProps {
@@ -104,7 +105,7 @@ export default function BlogSection({
       <div className="container">
         <div className="flex items-baseline justify-between mb-4">
           <h2 className="font-heading text-lg uppercase tracking-wider text-secondary">
-            {title || t("blog.title")}
+            <SplitFlap text={title || t("blog.title")} />
           </h2>
           {showSeeAll && (
             <motion.div whileHover={{ y: -2 }} transition={{ duration: 0.2 }}>
@@ -113,7 +114,7 @@ export default function BlogSection({
                 className="group flex items-center gap-2"
               >
                 <span className="font-body text-sg text-secondary group-hover:text-accent transition-colors">
-                  {t("blog.seeAll")}
+                  <SplitFlap text={t("blog.seeAll")} />
                 </span>
                 <span className="font-heading text-xl text-secondary group-hover:text-accent transition-colors">
                   →

--- a/packages/ui/gallery-section.tsx
+++ b/packages/ui/gallery-section.tsx
@@ -8,6 +8,7 @@ import { useIntersectionObserver } from "@portfolio/lib/hooks/use-intersection-o
 import { useLanguage } from "@portfolio/lib/contexts/language-context";
 import { motion } from "framer-motion";
 import NavigationLink from "@portfolio/ui/navigation-link";
+import { SplitFlap } from "@portfolio/ui/split-flap";
 interface GallerySectionProps {
   section?: string;
   title?: string;
@@ -193,7 +194,7 @@ export default function GallerySection({
       <div className="container">
         <div className="flex items-baseline justify-between mb-4">
           <h2 className="font-heading text-lg uppercase tracking-wider text-secondary">
-            {title || t("gallery.title")}
+            <SplitFlap text={title || t("gallery.title")} />
           </h2>
           {showSeeAll && (
             <motion.div whileHover={{ y: -2 }} transition={{ duration: 0.2 }}>
@@ -202,7 +203,7 @@ export default function GallerySection({
                 className="group flex items-center gap-2"
               >
                 <span className="font-body text-sg text-secondary group-hover:text-accent transition-colors">
-                  {t("gallery.seeAll")}
+                  <SplitFlap text={t("gallery.seeAll")} />
                 </span>
                 <span className="font-heading text-xl text-secondary group-hover:text-accent transition-colors">
                   →

--- a/packages/ui/image-container.tsx
+++ b/packages/ui/image-container.tsx
@@ -209,6 +209,7 @@ export function ImageContainer({
                       src={fullSrc}
                       alt={alt}
                       fill
+                      priority={priority}
                       className={`${noInsetPadding ? "object-cover" : "object-contain"} object-center transition-opacity duration-500 ${
                         blurComplete ? "opacity-100" : "opacity-0"
                       } ${imgClassName || ""}`}

--- a/packages/ui/sketches-section.tsx
+++ b/packages/ui/sketches-section.tsx
@@ -5,6 +5,7 @@ import SketchesCard from "./sketches-card";
 import { useIntersectionObserver } from "@portfolio/lib/hooks/use-intersection-observer";
 import { useLanguage } from "@portfolio/lib/contexts/language-context";
 import { motion, AnimatePresence } from "framer-motion";
+import { SplitFlap } from "@portfolio/ui/split-flap";
 
 interface SketchMetadata {
   slug: string;
@@ -134,7 +135,7 @@ export default function SketchesSection({
     <section ref={sectionRef} id={sectionId} className="py-12 md:py-16">
       <div className="container">
         <h2 className="font-heading text-lg uppercase tracking-wider text-secondary mb-4">
-          {t("sections.sketches")}
+          <SplitFlap text={t("sections.sketches")} />
         </h2>
         <div
           className={`w-full ${isLoading ? "min-h-[1200px] md:min-h-[400px]" : ""}`}

--- a/packages/ui/split-flap.tsx
+++ b/packages/ui/split-flap.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useReducedMotion } from "framer-motion";
+import { useLanguage } from "@portfolio/lib/contexts/language-context";
+
+// Vestaboard-style character cycling on language switch.
+// Per-character stagger inside a string + per-component stagger seeded by the
+// element's vertical position, so further-down nodes start later.
+
+const LATIN_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const CYCLES = 5;
+const STEP_MS = 38;
+const CHAR_STAGGER_MS = 22;
+const VERTICAL_STAGGER_MS_PER_PX = 0.35; // ~280ms across an 800px viewport
+
+const isCJK = (ch: string) => /[㐀-鿿豈-﫿]/.test(ch);
+
+function pickGlyph(target: string, pool: string[]): string {
+  if (!target || target === " ") return target;
+  if (isCJK(target)) {
+    // Sample from chars actually present in old+new strings — visually coherent
+    // and avoids landing on rare radicals from arithmetic on charCodeAt.
+    const cjk = pool.filter(isCJK);
+    return cjk.length
+      ? cjk[Math.floor(Math.random() * cjk.length)]
+      : target;
+  }
+  if (/\d/.test(target)) return String(Math.floor(Math.random() * 10));
+  if (/[a-zA-Z]/.test(target)) {
+    const ch = LATIN_UPPER[Math.floor(Math.random() * LATIN_UPPER.length)];
+    return /[a-z]/.test(target) ? ch.toLowerCase() : ch;
+  }
+  return target;
+}
+
+export function SplitFlap({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const { transitionTick } = useLanguage();
+  const reduce = useReducedMotion();
+  const [display, setDisplay] = useState(text);
+  const lastTickRef = useRef(transitionTick);
+  const prevTextRef = useRef(text);
+  const timersRef = useRef<number[]>([]);
+  const elRef = useRef<HTMLSpanElement | null>(null);
+
+  // Keep display in sync when no transition is active (e.g. text loaded late).
+  useEffect(() => {
+    if (transitionTick === lastTickRef.current) {
+      setDisplay(text);
+      prevTextRef.current = text;
+    }
+  }, [text, transitionTick]);
+
+  useEffect(() => {
+    if (transitionTick === lastTickRef.current) return;
+    lastTickRef.current = transitionTick;
+
+    const target = text;
+    const old = prevTextRef.current;
+    prevTextRef.current = target;
+
+    if (reduce || !target) {
+      setDisplay(target);
+      return;
+    }
+
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+
+    const maxLen = Math.max(target.length, old.length);
+    const chars = Array.from({ length: maxLen }, (_, i) => old[i] ?? " ");
+    const pool = Array.from(new Set([...old, ...target]));
+
+    // Vertical-position stagger: read once at transition start.
+    const top = elRef.current?.getBoundingClientRect().top ?? 0;
+    const offsetMs = Math.max(0, top) * VERTICAL_STAGGER_MS_PER_PX;
+
+    const commit = () => setDisplay(chars.join(""));
+
+    for (let i = 0; i < maxLen; i++) {
+      const base = offsetMs + i * CHAR_STAGGER_MS;
+      for (let c = 0; c < CYCLES; c++) {
+        const handle = window.setTimeout(() => {
+          chars[i] = pickGlyph(target[i] ?? " ", pool);
+          commit();
+        }, base + c * STEP_MS);
+        timersRef.current.push(handle);
+      }
+      const settle = window.setTimeout(() => {
+        chars[i] = target[i] ?? "";
+        commit();
+      }, base + CYCLES * STEP_MS);
+      timersRef.current.push(settle);
+    }
+
+    return () => {
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+    };
+  }, [text, transitionTick, reduce]);
+
+  return (
+    <span ref={elRef} className={className}>
+      {display}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Vestaboard-style character cycling fires when the language switcher toggles. Per-character stagger inside each string + per-component stagger seeded by `getBoundingClientRect().top` so further-down nodes start later (gradual downward feel).
- New `<SplitFlap>` primitive in `packages/ui/split-flap.tsx` (~113 LOC). Latin/digit pools for ASCII; CJK glyphs sampled from the old+new string pool to stay visually coherent. Instant swap under `prefers-reduced-motion`.
- `LanguageContext` exposes `transitionTick`, incremented once per user-initiated switch after the new namespaces finish loading. Additive only — the first-paint gate (`hasLoadedOnce` / overlay div) is untouched so the parallel FOUC fix can land cleanly in either order.
- Opt-in: applied to gallery/blog/sketches section headings + see-all labels as the first adopters.

## Test plan
- [ ] Toggle the switcher: glyphs cycle, settle to target text, components further down kick in later
- [ ] Toggle rapidly mid-animation: in-flight timers cancel cleanly, no stuck glyphs
- [ ] Enable `prefers-reduced-motion`: instant swap, no cycling
- [ ] First page load: no flap on initial render (only fires on explicit switch)
- [ ] EN ↔ zh-TW both directions look right; CJK glyphs stay readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated character-swapping text transitions during language changes
  
* **Improvements**
  * Images now utilize priority-based loading optimization
  * Section titles now display with animation effects across blog, gallery, and sketches sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->