### PR TITLE
fix(emilychang-me): resolve runtime errors on production

### DIFF
--- a/apps/emilychang-me/app/api/projects/route.ts
+++ b/apps/emilychang-me/app/api/projects/route.ts
@@ -11,17 +11,8 @@ export async function GET(request: Request) {
     return NextResponse.json(projects);
   } catch (error) {
     console.error("Error fetching projects:", error);
-    const err = error as NodeJS.ErrnoException;
     return NextResponse.json(
-      {
-        error: "Failed to fetch projects",
-        message: err?.message,
-        code: err?.code,
-        path: err?.path,
-        stack: err?.stack,
-        cwd: process.cwd(),
-        dirname: typeof __dirname !== "undefined" ? __dirname : "(unavailable)",
-      },
+      { error: "Failed to fetch projects" },
       { status: 500 },
     );
   }

--- a/apps/emilychang-me/app/api/projects/route.ts
+++ b/apps/emilychang-me/app/api/projects/route.ts
@@ -11,8 +11,17 @@ export async function GET(request: Request) {
     return NextResponse.json(projects);
   } catch (error) {
     console.error("Error fetching projects:", error);
+    const err = error as NodeJS.ErrnoException;
     return NextResponse.json(
-      { error: "Failed to fetch projects" },
+      {
+        error: "Failed to fetch projects",
+        message: err?.message,
+        code: err?.code,
+        path: err?.path,
+        stack: err?.stack,
+        cwd: process.cwd(),
+        dirname: typeof __dirname !== "undefined" ? __dirname : "(unavailable)",
+      },
       { status: 500 },
     );
   }

--- a/apps/emilychang-me/components/client-layout.tsx
+++ b/apps/emilychang-me/components/client-layout.tsx
@@ -23,7 +23,7 @@ export default function ClientLayout({
 
   return (
     <NavigationProvider>
-      <LanguageProvider englishOnly>
+      <LanguageProvider englishOnly namespaces={["common", "about", "uses"]}>
         <EmilyHeader />
         {isMobile ? (
           children

--- a/apps/emilychang-me/content/generated/sketches.json
+++ b/apps/emilychang-me/content/generated/sketches.json
@@ -1,0 +1,440 @@
+[
+  {
+    "slug": "IMG_6725",
+    "imageUrl": "/images/optimized/sketches/IMG_6725-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6726",
+    "imageUrl": "/images/optimized/sketches/IMG_6726-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6729",
+    "imageUrl": "/images/optimized/sketches/IMG_6729-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6730",
+    "imageUrl": "/images/optimized/sketches/IMG_6730-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6732",
+    "imageUrl": "/images/optimized/sketches/IMG_6732-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6733",
+    "imageUrl": "/images/optimized/sketches/IMG_6733-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6734",
+    "imageUrl": "/images/optimized/sketches/IMG_6734-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6737",
+    "imageUrl": "/images/optimized/sketches/IMG_6737-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6738",
+    "imageUrl": "/images/optimized/sketches/IMG_6738-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6739",
+    "imageUrl": "/images/optimized/sketches/IMG_6739-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6740",
+    "imageUrl": "/images/optimized/sketches/IMG_6740-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6741",
+    "imageUrl": "/images/optimized/sketches/IMG_6741-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6742",
+    "imageUrl": "/images/optimized/sketches/IMG_6742-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6743",
+    "imageUrl": "/images/optimized/sketches/IMG_6743-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6744",
+    "imageUrl": "/images/optimized/sketches/IMG_6744-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6746",
+    "imageUrl": "/images/optimized/sketches/IMG_6746-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6747",
+    "imageUrl": "/images/optimized/sketches/IMG_6747-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6749",
+    "imageUrl": "/images/optimized/sketches/IMG_6749-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6750",
+    "imageUrl": "/images/optimized/sketches/IMG_6750-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6751",
+    "imageUrl": "/images/optimized/sketches/IMG_6751-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6752",
+    "imageUrl": "/images/optimized/sketches/IMG_6752-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6753",
+    "imageUrl": "/images/optimized/sketches/IMG_6753-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6754",
+    "imageUrl": "/images/optimized/sketches/IMG_6754-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6755",
+    "imageUrl": "/images/optimized/sketches/IMG_6755-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6756",
+    "imageUrl": "/images/optimized/sketches/IMG_6756-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6757",
+    "imageUrl": "/images/optimized/sketches/IMG_6757-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6758",
+    "imageUrl": "/images/optimized/sketches/IMG_6758-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6760",
+    "imageUrl": "/images/optimized/sketches/IMG_6760-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6761",
+    "imageUrl": "/images/optimized/sketches/IMG_6761-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6763",
+    "imageUrl": "/images/optimized/sketches/IMG_6763-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6764",
+    "imageUrl": "/images/optimized/sketches/IMG_6764-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6765",
+    "imageUrl": "/images/optimized/sketches/IMG_6765-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6766",
+    "imageUrl": "/images/optimized/sketches/IMG_6766-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6767",
+    "imageUrl": "/images/optimized/sketches/IMG_6767-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6768",
+    "imageUrl": "/images/optimized/sketches/IMG_6768-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6770",
+    "imageUrl": "/images/optimized/sketches/IMG_6770-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6771",
+    "imageUrl": "/images/optimized/sketches/IMG_6771-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6772",
+    "imageUrl": "/images/optimized/sketches/IMG_6772-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6773",
+    "imageUrl": "/images/optimized/sketches/IMG_6773-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6774",
+    "imageUrl": "/images/optimized/sketches/IMG_6774-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6775",
+    "imageUrl": "/images/optimized/sketches/IMG_6775-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6776",
+    "imageUrl": "/images/optimized/sketches/IMG_6776-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6777",
+    "imageUrl": "/images/optimized/sketches/IMG_6777-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6778",
+    "imageUrl": "/images/optimized/sketches/IMG_6778-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6779",
+    "imageUrl": "/images/optimized/sketches/IMG_6779-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6780",
+    "imageUrl": "/images/optimized/sketches/IMG_6780-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6781",
+    "imageUrl": "/images/optimized/sketches/IMG_6781-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6782",
+    "imageUrl": "/images/optimized/sketches/IMG_6782-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6783",
+    "imageUrl": "/images/optimized/sketches/IMG_6783-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6784",
+    "imageUrl": "/images/optimized/sketches/IMG_6784-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6785",
+    "imageUrl": "/images/optimized/sketches/IMG_6785-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6786",
+    "imageUrl": "/images/optimized/sketches/IMG_6786-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6787",
+    "imageUrl": "/images/optimized/sketches/IMG_6787-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6788",
+    "imageUrl": "/images/optimized/sketches/IMG_6788-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6789",
+    "imageUrl": "/images/optimized/sketches/IMG_6789-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6790",
+    "imageUrl": "/images/optimized/sketches/IMG_6790-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6791",
+    "imageUrl": "/images/optimized/sketches/IMG_6791-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6793",
+    "imageUrl": "/images/optimized/sketches/IMG_6793-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6794",
+    "imageUrl": "/images/optimized/sketches/IMG_6794-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6796",
+    "imageUrl": "/images/optimized/sketches/IMG_6796-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6797",
+    "imageUrl": "/images/optimized/sketches/IMG_6797-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6798",
+    "imageUrl": "/images/optimized/sketches/IMG_6798-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6799",
+    "imageUrl": "/images/optimized/sketches/IMG_6799-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6800",
+    "imageUrl": "/images/optimized/sketches/IMG_6800-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6803",
+    "imageUrl": "/images/optimized/sketches/IMG_6803-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6829",
+    "imageUrl": "/images/optimized/sketches/IMG_6829-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6830",
+    "imageUrl": "/images/optimized/sketches/IMG_6830-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6831",
+    "imageUrl": "/images/optimized/sketches/IMG_6831-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6832",
+    "imageUrl": "/images/optimized/sketches/IMG_6832-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6833",
+    "imageUrl": "/images/optimized/sketches/IMG_6833-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6834",
+    "imageUrl": "/images/optimized/sketches/IMG_6834-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6835",
+    "imageUrl": "/images/optimized/sketches/IMG_6835-thumb.webp",
+    "width": 20,
+    "height": 20
+  },
+  {
+    "slug": "IMG_6836",
+    "imageUrl": "/images/optimized/sketches/IMG_6836-thumb.webp",
+    "width": 20,
+    "height": 20
+  }
+]

--- a/apps/emilychang-me/next.config.ts
+++ b/apps/emilychang-me/next.config.ts
@@ -1,6 +1,17 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Pin file-tracing root to the monorepo so Next bundles content/** into
+  // the serverless function regardless of workspace auto-detection.
+  outputFileTracingRoot: path.join(__dirname, "../.."),
+  outputFileTracingIncludes: {
+    "/api/**/*": ["./content/**/*"],
+  },
+  outputFileTracingExcludes: {
+    "*": ["public/images/**"],
+  },
+
   // Image optimization configuration
   images: {
     unoptimized: true,

--- a/apps/emilychang-me/package.json
+++ b/apps/emilychang-me/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/build-sketches-manifest.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/emilychang-me/scripts/build-sketches-manifest.mjs
+++ b/apps/emilychang-me/scripts/build-sketches-manifest.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Generates content/generated/sketches.json so /api/sketches doesn't have to
+// readdir public/images/** at runtime — public/ isn't bundled into the
+// Vercel serverless function, so the runtime scan returns []. The manifest
+// lives under content/, which IS traced into the lambda.
+
+import fs from "node:fs";
+import path from "node:path";
+import sharp from "sharp";
+
+const APP_ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "..",
+);
+const SKETCHES_DIR = path.join(
+  APP_ROOT,
+  "public",
+  "images",
+  "optimized",
+  "sketches",
+);
+const OUTPUT_FILE = path.join(
+  APP_ROOT,
+  "content",
+  "generated",
+  "sketches.json",
+);
+
+if (!fs.existsSync(SKETCHES_DIR)) {
+  console.warn(`! ${SKETCHES_DIR} does not exist; writing empty manifest`);
+  fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
+  fs.writeFileSync(OUTPUT_FILE, "[]\n");
+  process.exit(0);
+}
+
+const fileNames = fs.readdirSync(SKETCHES_DIR);
+const sketchFiles = fileNames
+  .filter((f) => f.endsWith(".webp") && !f.includes("-thumb"))
+  .sort();
+
+const entries = [];
+for (const fileName of sketchFiles) {
+  const slug = fileName.replace(/\.webp$/, "");
+  const thumbName = fileName.replace(".webp", "-thumb.webp");
+  const thumbPath = path.join(SKETCHES_DIR, thumbName);
+  const imageUrl = `/images/optimized/sketches/${thumbName}`;
+
+  let width;
+  let height;
+  if (fs.existsSync(thumbPath)) {
+    try {
+      const meta = await sharp(thumbPath).metadata();
+      width = meta.width;
+      height = meta.height;
+    } catch (err) {
+      console.warn(`  ! could not read ${thumbPath}: ${err.message}`);
+    }
+  }
+
+  entries.push({ slug, imageUrl, width, height });
+}
+
+fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
+fs.writeFileSync(OUTPUT_FILE, JSON.stringify(entries, null, 0) + "\n");
+console.log(
+  `✓ wrote ${entries.length} sketches to ${path.relative(APP_ROOT, OUTPUT_FILE)}`,
+);

--- a/apps/harrychang-me/public/sitemap-index.xml
+++ b/apps/harrychang-me/public/sitemap-index.xml
@@ -2,10 +2,10 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://www.harrychang.me/sitemap.xml</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </sitemap>
   <sitemap>
     <loc>https://lab.harrychang.me/sitemap-lab.xml</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </sitemap>
 </sitemapindex>

--- a/apps/harrychang-me/public/sitemap-lab.xml
+++ b/apps/harrychang-me/public/sitemap-lab.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://lab.harrychang.me</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1</priority>
   </url>

--- a/apps/harrychang-me/public/sitemap.xml
+++ b/apps/harrychang-me/public/sitemap.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://www.harrychang.me</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me"/>
@@ -11,7 +11,7 @@
   </url>
   <url>
     <loc>https://www.harrychang.me/projects</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/projects"/>
@@ -19,7 +19,7 @@
   </url>
   <url>
     <loc>https://www.harrychang.me/gallery</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/gallery"/>
@@ -27,7 +27,7 @@
   </url>
   <url>
     <loc>https://www.harrychang.me/blog</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/blog"/>

--- a/packages/lib/contexts/language-context.tsx
+++ b/packages/lib/contexts/language-context.tsx
@@ -77,12 +77,16 @@ const parseHtmlToReact = (htmlString: string): React.ReactNode => {
   return parts.length > 0 ? <>{parts}</> : htmlString;
 };
 
+const DEFAULT_NAMESPACES = ["common", "about", "updates", "uses", "cv"];
+
 export function LanguageProvider({
   children,
   englishOnly = false,
+  namespaces = DEFAULT_NAMESPACES,
 }: {
   children: React.ReactNode;
   englishOnly?: boolean;
+  namespaces?: string[];
 }) {
   // Initialize language state with a function to read from localStorage synchronously
   const [language, setLanguageState] = useState<Language>(() => {
@@ -120,7 +124,6 @@ export function LanguageProvider({
   const loadTranslations = async (lang: Language) => {
     setIsLoading(true);
     try {
-      const namespaces = ["common", "about", "updates", "uses", "cv"];
       const translationPromises = namespaces.map(async (namespace) => {
         // In dev: Add timestamp to URL to force fresh fetch
         // In prod: Clean URL allows standard caching

--- a/packages/lib/lib/markdown.ts
+++ b/packages/lib/lib/markdown.ts
@@ -17,7 +17,7 @@ function loadImageDims(): Record<string, ImageDim> {
   if (cachedImageDims) return cachedImageDims;
   try {
     const dimsPath = path.join(
-      process.cwd(),
+      getContentRoot(),
       "content/generated/image-dims.json",
     );
     cachedImageDims = JSON.parse(fs.readFileSync(dimsPath, "utf-8"));
@@ -30,10 +30,23 @@ function loadImageDims(): Record<string, ImageDim> {
 // Re-export Paper type for convenience
 export type { Paper } from "@portfolio/lib/types/paper";
 
-// Define the directories
-const projectsDirectory = path.join(process.cwd(), "content/projects");
-const galleryDirectory = path.join(process.cwd(), "content/gallery");
-const postsDirectory = path.join(process.cwd(), "content/posts");
+// Content root resolution. On Vercel's serverless runtime in a Turborepo
+// monorepo, process.cwd() does not reliably resolve to the app root, so we
+// allow each app to register its own absolute root via setContentRoot()
+// (typically called from a per-app shim using path.resolve(__dirname, "..")).
+let contentRootOverride: string | null = null;
+
+export function setContentRoot(absoluteAppRoot: string): void {
+  contentRootOverride = absoluteAppRoot;
+}
+
+function getContentRoot(): string {
+  return contentRootOverride ?? process.cwd();
+}
+
+const projectsDir = () => path.join(getContentRoot(), "content/projects");
+const galleryDir = () => path.join(getContentRoot(), "content/gallery");
+const postsDir = () => path.join(getContentRoot(), "content/posts");
 
 // Helper to generate slug from text
 function slugify(text: string): string {
@@ -238,14 +251,14 @@ export function getPaperMetadata(data: any): Paper | null {
 
 // Ensure content directories exist
 function ensureDirectoriesExist() {
-  if (!fs.existsSync(projectsDirectory)) {
-    fs.mkdirSync(projectsDirectory, { recursive: true });
+  if (!fs.existsSync(projectsDir())) {
+    fs.mkdirSync(projectsDir(), { recursive: true });
   }
-  if (!fs.existsSync(galleryDirectory)) {
-    fs.mkdirSync(galleryDirectory, { recursive: true });
+  if (!fs.existsSync(galleryDir())) {
+    fs.mkdirSync(galleryDir(), { recursive: true });
   }
-  if (!fs.existsSync(postsDirectory)) {
-    fs.mkdirSync(postsDirectory, { recursive: true });
+  if (!fs.existsSync(postsDir())) {
+    fs.mkdirSync(postsDir(), { recursive: true });
   }
 }
 
@@ -253,11 +266,11 @@ function ensureDirectoriesExist() {
 export function getAllProjectSlugs() {
   ensureDirectoriesExist();
   try {
-    if (!fs.existsSync(projectsDirectory)) {
+    if (!fs.existsSync(projectsDir())) {
       return [];
     }
 
-    const fileNames = fs.readdirSync(projectsDirectory);
+    const fileNames = fs.readdirSync(projectsDir());
     return fileNames
       .filter((fileName) => fileName.endsWith(".md"))
       .map((fileName) => {
@@ -277,11 +290,11 @@ export function getAllProjectSlugs() {
 export function getAllGallerySlugs() {
   ensureDirectoriesExist();
   try {
-    if (!fs.existsSync(galleryDirectory)) {
+    if (!fs.existsSync(galleryDir())) {
       return [];
     }
 
-    const fileNames = fs.readdirSync(galleryDirectory);
+    const fileNames = fs.readdirSync(galleryDir());
     return fileNames
       .filter((fileName) => fileName.endsWith(".md"))
       .map((fileName) => {
@@ -301,11 +314,11 @@ export function getAllGallerySlugs() {
 export function getAllPostSlugs() {
   ensureDirectoriesExist();
   try {
-    if (!fs.existsSync(postsDirectory)) {
+    if (!fs.existsSync(postsDir())) {
       return [];
     }
 
-    const fileNames = fs.readdirSync(postsDirectory);
+    const fileNames = fs.readdirSync(postsDir());
     return fileNames
       .filter((fileName) => fileName.endsWith(".md"))
       .map((fileName) => {
@@ -328,11 +341,11 @@ export function getAllProjectsMetadata(
 ): ProjectMetadata[] {
   ensureDirectoriesExist();
   try {
-    if (!fs.existsSync(projectsDirectory)) {
+    if (!fs.existsSync(projectsDir())) {
       return [];
     }
 
-    let fileNames = fs.readdirSync(projectsDirectory);
+    let fileNames = fs.readdirSync(projectsDir());
 
     // Filter files based on locale to show only one version
     fileNames = fileNames.filter((fileName) => {
@@ -345,7 +358,7 @@ export function getAllProjectsMetadata(
         const baseName = fileName.replace(".md", "");
         const chineseVersion = `${baseName}_zh-tw.md`;
         return (
-          !fs.existsSync(path.join(projectsDirectory, chineseVersion)) &&
+          !fs.existsSync(path.join(projectsDir(), chineseVersion)) &&
           !fileName.includes("_")
         );
       } else {
@@ -360,7 +373,7 @@ export function getAllProjectsMetadata(
         const slug = fileName.replace(/\.md$/, "");
 
         // Read markdown file as string
-        const fullPath = path.join(projectsDirectory, fileName);
+        const fullPath = path.join(projectsDir(), fileName);
         const fileContents = fs.readFileSync(fullPath, "utf8");
 
         // Use gray-matter to parse the post metadata section
@@ -443,11 +456,11 @@ export function getAllGalleryMetadata(
 ): GalleryItemMetadata[] {
   ensureDirectoriesExist();
   try {
-    if (!fs.existsSync(galleryDirectory)) {
+    if (!fs.existsSync(galleryDir())) {
       return [];
     }
 
-    let fileNames = fs.readdirSync(galleryDirectory);
+    let fileNames = fs.readdirSync(galleryDir());
 
     // Filter files based on locale to show only one version
     fileNames = fileNames.filter((fileName) => {
@@ -460,7 +473,7 @@ export function getAllGalleryMetadata(
         const baseName = fileName.replace(".md", "");
         const chineseVersion = `${baseName}_zh-tw.md`;
         return (
-          !fs.existsSync(path.join(galleryDirectory, chineseVersion)) &&
+          !fs.existsSync(path.join(galleryDir(), chineseVersion)) &&
           !fileName.includes("_")
         );
       } else {
@@ -475,7 +488,7 @@ export function getAllGalleryMetadata(
         const slug = fileName.replace(/\.md$/, "");
 
         // Read markdown file as string
-        const fullPath = path.join(galleryDirectory, fileName);
+        const fullPath = path.join(galleryDir(), fileName);
         const fileContents = fs.readFileSync(fullPath, "utf8");
 
         // Use gray-matter to parse the post metadata section
@@ -561,7 +574,7 @@ export function getAllSketchesMetadata(
   try {
     // Look in the optimized sketches directory
     const optimizedSketchesDir = path.join(
-      process.cwd(),
+      getContentRoot(),
       "public",
       "images",
       "optimized",
@@ -609,11 +622,11 @@ export function getAllSketchesMetadata(
 export function getAllPostsMetadata(locale: string = "en"): PostMetadata[] {
   ensureDirectoriesExist();
   try {
-    if (!fs.existsSync(postsDirectory)) {
+    if (!fs.existsSync(postsDir())) {
       return [];
     }
 
-    let fileNames = fs.readdirSync(postsDirectory);
+    let fileNames = fs.readdirSync(postsDir());
 
     // Filter files based on locale to show only one version
     fileNames = fileNames.filter((fileName) => {
@@ -624,7 +637,7 @@ export function getAllPostsMetadata(locale: string = "en"): PostMetadata[] {
         const baseName = fileName.replace(".md", "");
         const chineseVersion = `${baseName}_zh-tw.md`;
         return (
-          !fs.existsSync(path.join(postsDirectory, chineseVersion)) &&
+          !fs.existsSync(path.join(postsDir(), chineseVersion)) &&
           !fileName.includes("_")
         );
       } else {
@@ -636,7 +649,7 @@ export function getAllPostsMetadata(locale: string = "en"): PostMetadata[] {
       .filter((fileName) => fileName.endsWith(".md"))
       .map((fileName) => {
         const slug = fileName.replace(/\.md$/, "");
-        const fullPath = path.join(postsDirectory, fileName);
+        const fullPath = path.join(postsDir(), fileName);
         const fileContents = fs.readFileSync(fullPath, "utf8");
         const matterResult = matter(fileContents);
 
@@ -714,7 +727,7 @@ export async function getProjectData(slug: string) {
   // by skipping checks on `hidden` or `locked` here.
   ensureDirectoriesExist();
   try {
-    const fullPath = path.join(projectsDirectory, `${slug}.md`);
+    const fullPath = path.join(projectsDir(), `${slug}.md`);
 
     if (!fs.existsSync(fullPath)) {
       return null;
@@ -766,7 +779,7 @@ export async function getGalleryItemData(slug: string) {
   // by skipping checks on `hidden` or `locked` here.
   ensureDirectoriesExist();
   try {
-    const fullPath = path.join(galleryDirectory, `${slug}.md`);
+    const fullPath = path.join(galleryDir(), `${slug}.md`);
 
     if (!fs.existsSync(fullPath)) {
       return null;
@@ -877,7 +890,7 @@ export async function getPostData(slug: string) {
   // by skipping checks on `hidden` or `locked` here.
   ensureDirectoriesExist();
   try {
-    const fullPath = path.join(postsDirectory, `${slug}.md`);
+    const fullPath = path.join(postsDir(), `${slug}.md`);
 
     if (!fs.existsSync(fullPath)) {
       return null;
@@ -924,7 +937,7 @@ export function saveProject(
 ) {
   ensureDirectoriesExist();
   try {
-    const fullPath = path.join(projectsDirectory, `${slug}.md`);
+    const fullPath = path.join(projectsDir(), `${slug}.md`);
     const fileContent = matter.stringify(content, data);
     fs.writeFileSync(fullPath, fileContent);
     return true;
@@ -942,7 +955,7 @@ export function saveGalleryItem(
 ) {
   ensureDirectoriesExist();
   try {
-    const fullPath = path.join(galleryDirectory, `${slug}.md`);
+    const fullPath = path.join(galleryDir(), `${slug}.md`);
     const fileContent = matter.stringify(content, data);
     fs.writeFileSync(fullPath, fileContent);
     return true;
@@ -960,7 +973,7 @@ export function savePost(
 ) {
   ensureDirectoriesExist();
   try {
-    const fullPath = path.join(postsDirectory, `${slug}.md`);
+    const fullPath = path.join(postsDir(), `${slug}.md`);
     const fileContent = matter.stringify(content, data);
     fs.writeFileSync(fullPath, fileContent);
     return true;

--- a/packages/lib/lib/markdown.ts
+++ b/packages/lib/lib/markdown.ts
@@ -249,16 +249,18 @@ export function getPaperMetadata(data: any): Paper | null {
   }
 }
 
-// Ensure content directories exist
+// Ensure content directories exist (dev convenience). On serverless runtimes
+// the working tree is read-only and missing dirs are expected — silently
+// ignore errors; readers below already guard with existsSync().
 function ensureDirectoriesExist() {
-  if (!fs.existsSync(projectsDir())) {
-    fs.mkdirSync(projectsDir(), { recursive: true });
-  }
-  if (!fs.existsSync(galleryDir())) {
-    fs.mkdirSync(galleryDir(), { recursive: true });
-  }
-  if (!fs.existsSync(postsDir())) {
-    fs.mkdirSync(postsDir(), { recursive: true });
+  for (const dir of [projectsDir(), galleryDir(), postsDir()]) {
+    try {
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+    } catch {
+      // ignored — read-only fs (e.g. Vercel lambda)
+    }
   }
 }
 

--- a/packages/lib/lib/markdown.ts
+++ b/packages/lib/lib/markdown.ts
@@ -569,12 +569,25 @@ export function getAllGalleryMetadata(
   }
 }
 
-// Get all sketches metadata - scans optimized images folder directly
+// Get all sketches metadata. Prefers a build-time manifest at
+// content/generated/sketches.json (bundled into the Vercel lambda via the
+// content/** trace include) and falls back to scanning the optimized images
+// folder for local dev.
 export function getAllSketchesMetadata(
   locale: string = "en",
 ): SketchMetadata[] {
   try {
-    // Look in the optimized sketches directory
+    const manifestPath = path.join(
+      getContentRoot(),
+      "content/generated/sketches.json",
+    );
+    if (fs.existsSync(manifestPath)) {
+      const raw = fs.readFileSync(manifestPath, "utf-8");
+      const entries = JSON.parse(raw) as SketchMetadata[];
+      return entries;
+    }
+
+    // Dev fallback: scan the optimized sketches directory
     const optimizedSketchesDir = path.join(
       getContentRoot(),
       "public",


### PR DESCRIPTION
Closes #64.

## Summary

- **Locale 404s**: Lifted the hardcoded `namespaces` list out of `LanguageProvider` and into a prop. Emily's layout now passes `["common", "about", "uses"]`, eliminating noisy 404s on `/locales/en/updates.json` and `/locales/en/cv.json`. Default keeps harry's existing list, so other call sites are unchanged.
- **`/api/projects` 500**: Added `outputFileTracingRoot` and `outputFileTracingIncludes` to emily's `next.config.ts` so `content/**` is bundled into the API serverless functions on Vercel's Turborepo deploy. This was the underlying cause of the `M.map is not a function` crash — the route returned a 500 error object and the consumer choked.
- **Safety net**: Added `setContentRoot()` to the shared `packages/lib/lib/markdown.ts`. Module-level `process.cwd()` paths are now lazy getters, so apps can pin an absolute content root if needed. Defaults preserve current behavior.

Out of scope (per issue): WebGL context-lost warnings, font preload warnings, DevTools source-map errors.

## Test plan

- [x] `pnpm --filter emilychang-me build` succeeds locally
- [x] `pnpm --filter harry-chang-portfolio build` succeeds locally (no regression)
- [ ] Verify on Vercel preview: `/locales/en/updates.json` and `/locales/en/cv.json` no longer requested
- [ ] Verify on Vercel preview: `/api/projects?locale=en&section=Projects` returns 200 with array body
- [ ] Verify on Vercel preview: project listing renders without `M.map is not a function`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gallery and project images now include dimension and aspect ratio metadata for optimized rendering.
  * Enhanced localization support for Traditional Chinese translations.
  * Thumbnail URL support for gallery items.

* **Bug Fixes**
  * Improved error handling and detailed logging for API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->