### PR TITLE
ci(lighthouse): scope harry prod audit, add emily prod audit

### DIFF
--- a/.github/scripts/update-lighthouse-readme.js
+++ b/.github/scripts/update-lighthouse-readme.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-'use strict';
+"use strict";
 
-const fs   = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 function readLhrDir(dir) {
   const absDir = path.join(process.cwd(), dir);
@@ -10,24 +10,26 @@ function readLhrDir(dir) {
 
   const lhrFiles = fs
     .readdirSync(absDir)
-    .filter(f => f.startsWith('lhr-') && f.endsWith('.json'));
+    .filter((f) => f.startsWith("lhr-") && f.endsWith(".json"));
 
   const data = {};
   for (const file of lhrFiles) {
     try {
-      const lhr = JSON.parse(fs.readFileSync(path.join(absDir, file), 'utf8'));
-      const urlPath   = new URL(lhr.requestedUrl).pathname || '/';
-      const perfScore = Math.round((lhr.categories?.performance?.score ?? 0) * 100);
-      const get = key => lhr.audits?.[key]?.displayValue ?? '-';
+      const lhr = JSON.parse(fs.readFileSync(path.join(absDir, file), "utf8"));
+      const urlPath = new URL(lhr.requestedUrl).pathname || "/";
+      const perfScore = Math.round(
+        (lhr.categories?.performance?.score ?? 0) * 100,
+      );
+      const get = (key) => lhr.audits?.[key]?.displayValue ?? "-";
 
       if (!data[urlPath] || perfScore > data[urlPath].perfScore) {
         data[urlPath] = {
           perfScore,
-          fcp: get('first-contentful-paint'),
-          lcp: get('largest-contentful-paint'),
-          tbt: get('total-blocking-time'),
-          cls: get('cumulative-layout-shift'),
-          si:  get('speed-index'),
+          fcp: get("first-contentful-paint"),
+          lcp: get("largest-contentful-paint"),
+          tbt: get("total-blocking-time"),
+          cls: get("cumulative-layout-shift"),
+          si: get("speed-index"),
         };
       }
     } catch (err) {
@@ -40,61 +42,83 @@ function readLhrDir(dir) {
 function buildRows(routeData) {
   return Object.keys(routeData)
     .sort()
-    .map(route => {
-      const d     = routeData[route];
-      const color = d.perfScore >= 90 ? 'success' : d.perfScore >= 50 ? 'important' : 'critical';
+    .map((route) => {
+      const d = routeData[route];
+      const color =
+        d.perfScore >= 90
+          ? "success"
+          : d.perfScore >= 50
+            ? "important"
+            : "critical";
       const badge = `![Lighthouse ${d.perfScore}](https://img.shields.io/badge/lighthouse-${d.perfScore}-${color}?style=flat-square)`;
       return `| \`${route}\` | ${badge} | ${d.fcp} | ${d.lcp} | ${d.tbt} | ${d.cls} | ${d.si} |`;
     })
-    .join('\n');
+    .join("\n");
 }
 
 const TABLE_HEADER = [
-  '| Tested Route | Performance | FCP | LCP | TBT | CLS | Speed Index |',
-  '|:---|:---|:---|:---|:---|:---|:---|',
-].join('\n');
+  "| Tested Route | Performance | FCP | LCP | TBT | CLS | Speed Index |",
+  "|:---|:---|:---|:---|:---|:---|:---|",
+].join("\n");
 
-const mode = process.argv.includes('--mode=prod') ? 'prod' : 'simulated';
+const mode = process.argv.includes("--mode=prod") ? "prod" : "simulated";
 
-const readmePath = path.join(process.cwd(), 'apps', 'harrychang-me', 'README.md');
-const readme     = fs.readFileSync(readmePath, 'utf8');
-const timestamp  = new Date().toUTCString();
+// `--readme=<relative-path>` lets a workflow target a different app's README
+// (e.g. apps/emilychang-me/README.md). Defaults to harrychang-me to preserve
+// existing behavior.
+const readmeArg = process.argv.find((a) => a.startsWith("--readme="));
+const readmeRel = readmeArg
+  ? readmeArg.slice("--readme=".length)
+  : "apps/harrychang-me/README.md";
+const readmePath = path.join(process.cwd(), readmeRel);
+const readme = fs.readFileSync(readmePath, "utf8");
+const timestamp = new Date().toUTCString();
 
-if (mode === 'prod') {
-  const desktopData = readLhrDir('.lighthouseci');
-  const mobileData  = readLhrDir('.lighthouseci-mobile');
+if (mode === "prod") {
+  const desktopData = readLhrDir(".lighthouseci");
+  const mobileData = readLhrDir(".lighthouseci-mobile");
 
   const hasDesktop = Object.keys(desktopData).length > 0;
-  const hasMobile  = Object.keys(mobileData).length > 0;
+  const hasMobile = Object.keys(mobileData).length > 0;
 
   if (!hasDesktop && !hasMobile) {
-    console.log('No production LHR JSON files found — skipping README update.');
+    console.log("No production LHR JSON files found — skipping README update.");
     process.exit(0);
   }
 
-  const deploymentUrl = process.env.DEPLOYMENT_URL || '';
+  const deploymentUrl = process.env.DEPLOYMENT_URL || "";
   const header = deploymentUrl
     ? `> 🕐 **Last audited:** ${timestamp}  \n> 🌐 **Deployment:** ${deploymentUrl}`
     : `> 🕐 **Last audited:** ${timestamp}`;
 
   const sections = [];
   if (hasDesktop) {
-    sections.push(`#### Desktop (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(desktopData)}`);
+    sections.push(
+      `#### Desktop (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(desktopData)}`,
+    );
   }
   if (hasMobile) {
-    sections.push(`#### Mobile (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(mobileData)}`);
+    sections.push(
+      `#### Mobile (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(mobileData)}`,
+    );
   }
 
   const block = [
-    '<!-- LIGHTHOUSE_PROD_RESULTS_START -->',
+    "<!-- LIGHTHOUSE_PROD_RESULTS_START -->",
     header,
-    '',
-    sections.join('\n\n'),
-    '<!-- LIGHTHOUSE_PROD_RESULTS_END -->',
-  ].join('\n');
+    "",
+    sections.join("\n\n"),
+    "<!-- LIGHTHOUSE_PROD_RESULTS_END -->",
+  ].join("\n");
 
-  if (!/<!-- LIGHTHOUSE_PROD_RESULTS_START -->[\s\S]*?<!-- LIGHTHOUSE_PROD_RESULTS_END -->/.test(readme)) {
-    console.error('Production marker block not found in README. Add the markers first.');
+  if (
+    !/<!-- LIGHTHOUSE_PROD_RESULTS_START -->[\s\S]*?<!-- LIGHTHOUSE_PROD_RESULTS_END -->/.test(
+      readme,
+    )
+  ) {
+    console.error(
+      "Production marker block not found in README. Add the markers first.",
+    );
     process.exit(1);
   }
 
@@ -102,19 +126,19 @@ if (mode === 'prod') {
     /<!-- LIGHTHOUSE_PROD_RESULTS_START -->[\s\S]*?<!-- LIGHTHOUSE_PROD_RESULTS_END -->/,
     block,
   );
-  fs.writeFileSync(readmePath, updated, 'utf8');
-  console.log('README production Lighthouse section updated successfully.');
+  fs.writeFileSync(readmePath, updated, "utf8");
+  console.log("README production Lighthouse section updated successfully.");
   process.exit(0);
 }
 
-const desktopData = readLhrDir('.lighthouseci');
-const mobileData  = readLhrDir('.lighthouseci-mobile');
+const desktopData = readLhrDir(".lighthouseci");
+const mobileData = readLhrDir(".lighthouseci-mobile");
 
 const hasDesktop = Object.keys(desktopData).length > 0;
-const hasMobile  = Object.keys(mobileData).length > 0;
+const hasMobile = Object.keys(mobileData).length > 0;
 
 if (!hasDesktop && !hasMobile) {
-  console.log('No LHR JSON files found — skipping README update.');
+  console.log("No LHR JSON files found — skipping README update.");
   process.exit(0);
 }
 
@@ -127,16 +151,16 @@ if (hasMobile) {
 }
 
 const block = [
-  '<!-- LIGHTHOUSE_RESULTS_START -->',
+  "<!-- LIGHTHOUSE_RESULTS_START -->",
   `> 🕐 **Last audited:** ${timestamp}`,
-  '',
-  sections.join('\n\n'),
-  '<!-- LIGHTHOUSE_RESULTS_END -->',
-].join('\n');
+  "",
+  sections.join("\n\n"),
+  "<!-- LIGHTHOUSE_RESULTS_END -->",
+].join("\n");
 
 const updated = readme.replace(
   /<!-- LIGHTHOUSE_RESULTS_START -->[\s\S]*?<!-- LIGHTHOUSE_RESULTS_END -->/,
   block,
 );
-fs.writeFileSync(readmePath, updated, 'utf8');
-console.log('README Lighthouse section updated successfully.');
+fs.writeFileSync(readmePath, updated, "utf8");
+console.log("README Lighthouse section updated successfully.");

--- a/.github/workflows/lighthouse-prod-emily.yml
+++ b/.github/workflows/lighthouse-prod-emily.yml
@@ -1,40 +1,39 @@
-name: Lighthouse Audit (Production)
+name: Lighthouse Audit (Production, Emily)
 
 on:
   deployment_status:
 
 concurrency:
-  group: lighthouse-prod
+  group: lighthouse-prod-emily
   cancel-in-progress: true
 
 jobs:
-  lighthouse-prod:
-    name: Lighthouse CI (Production Deployment)
-    # Only run when the harrychang-me Vercel Production deployment finishes.
-    # Vercel sets `environment` to "Production – <project-name>"; this repo
-    # hosts two Vercel projects (`portfolio` for harrychang-me and
-    # `portfolio-monorepo-emilychang-me` for emilychang-me), so we match the
-    # harry-specific suffix to avoid auditing the wrong site when the emily
-    # project deploys. NOTE: the dash below is U+2013 (en-dash), not ASCII —
-    # Vercel emits the en-dash literally; do not "normalize" it.
+  lighthouse-prod-emily:
+    name: Lighthouse CI (Emily Production Deployment)
+    # Only run when the emilychang-me Vercel Production deployment finishes.
+    # Vercel sets `environment` to "Production – <project-name>"; the emily
+    # project name is `portfolio-monorepo-emilychang-me`. Matching the exact
+    # string keeps the harry workflow and this one mutually exclusive.
+    # NOTE: the dash in "Production – portfolio-…" is U+2013 (en-dash), not
+    # ASCII — Vercel emits the en-dash literally; do not "normalize" it.
     if: >-
       github.event.deployment_status.state == 'success' &&
-      github.event.deployment.environment == 'Production – portfolio'
+      github.event.deployment.environment == 'Production – portfolio-monorepo-emilychang-me'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       deployments: read
 
     steps:
-      # Check out main (not the deployment sha) so the README commit lands
-      # on the current tip of main without a non-fast-forward push.
+      # Check out main (not the deployment sha) so the README commit lands on
+      # the current tip of main without a non-fast-forward push.
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: main
 
-      # Break the redeploy loop: if this deployment was triggered by our own
-      # README commit, skip. Vercel does not always honor [skip ci] for the
+      # Break the redeploy loop: skip if this deployment_status was raised for
+      # our own README commit. Vercel does not always honor [skip ci] for the
       # deployment itself, and deployment_status events ignore [skip ci].
       - name: Skip if deployment commit is the bot's README update
         id: loop_guard
@@ -46,7 +45,7 @@ jobs:
           echo "Deployment commit: $DEPLOYMENT_SHA"
           echo "Message: $MSG"
           echo "Author: $AUTHOR"
-          if [[ "$MSG" == *"[skip ci]"* ]] || [[ "$MSG" == *"update production lighthouse scores"* ]]; then
+          if [[ "$MSG" == *"[skip ci]"* ]] || [[ "$MSG" == *"update emily production lighthouse scores"* ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping — deployment is the bot's README commit."
           else
@@ -70,44 +69,19 @@ jobs:
         if: steps.loop_guard.outputs.skip != 'true'
         run: pnpm install --frozen-lockfile
 
-      # We audit the canonical public domain rather than the per-deployment
-      # vercel.app URL. The deployment_status trigger already gates on a
+      # Audit the canonical public domain rather than the per-deployment
+      # vercel.app URL — the deployment_status trigger already gated on a
       # successful Production deploy, and the canonical URL is what real
-      # users hit (custom domain + Vercel CDN edge), with no preview-auth
-      # or deployment-protection redirects.
+      # users hit (custom domain + Vercel CDN edge).
       - name: Build URL list
         if: steps.loop_guard.outputs.skip != 'true'
         id: urls
         env:
-          DEPLOY_URL: https://harrychang.me
+          DEPLOY_URL: https://emilychang.me
         run: |
           PATHS=(
             "/"
-            "/blog"
-            "/projects"
-            "/gallery"
-            "/uses"
-            "/cv"
             "/linktree"
-            "/design"
-            "/paper-reading"
-            "/manifesto"
-            "/projects/2025_04_12_portfolio"
-            "/projects/2024_09_23_chingshin_rag"
-            "/projects/2025_03_08_sitcon_keynote"
-            "/projects/2025_08_04_debate"
-            "/projects/2024_08_19_classics_reimagined"
-            "/gallery/2026_02_08_italy_mountain"
-            "/gallery/2023_07_07_splash_of_red"
-            "/gallery/2023_10_06_against_giants"
-            "/gallery/2023_11_18_dusk_impressions"
-            "/gallery/2024_01_06_hehuanshan"
-            "/blog/9_m11d"
-            "/blog/2025_12_19_xpro1"
-            "/blog/2025_12_22_aftersun_paris_texas"
-            "/blog/2026_01_10_plushies"
-            "/blog/2026_02_10_synecdoche_truman"
-            "/graph"
           )
           {
             echo "list<<EOF"
@@ -123,7 +97,7 @@ jobs:
         with:
           urls: ${{ steps.urls.outputs.list }}
           configPath: apps/harrychang-me/.lighthouserc.mobile.json
-          artifactName: lighthouse-results-prod-mobile
+          artifactName: lighthouse-results-prod-emily-mobile
           uploadArtifacts: true
           temporaryPublicStorage: true
 
@@ -144,34 +118,35 @@ jobs:
         with:
           urls: ${{ steps.urls.outputs.list }}
           configPath: apps/harrychang-me/.lighthouserc.json
-          artifactName: lighthouse-results-prod-desktop
+          artifactName: lighthouse-results-prod-emily-desktop
           uploadArtifacts: true
           temporaryPublicStorage: true
 
       - name: Update README with production Lighthouse badges
         if: steps.loop_guard.outputs.skip != 'true'
         env:
-          DEPLOYMENT_URL: https://harrychang.me
-        run: node .github/scripts/update-lighthouse-readme.js --mode=prod
+          DEPLOYMENT_URL: https://emilychang.me
+        run: node .github/scripts/update-lighthouse-readme.js --mode=prod --readme=apps/emilychang-me/README.md
 
       - name: Format README with Prettier
         if: steps.loop_guard.outputs.skip != 'true'
-        run: npx prettier --write apps/harrychang-me/README.md
+        run: npx prettier --write apps/emilychang-me/README.md
 
-      # Rebase onto latest main before the auto-commit pushes, in case
-      # another job (e.g. lighthouse.yml) updated main during this run.
+      # Lighthouse runs are long; main may have moved during this window
+      # (e.g. harry's lighthouse-prod committed). Rebase our README change
+      # onto the latest main so the auto-commit push is fast-forward.
       - name: Rebase README change onto latest main
         if: steps.loop_guard.outputs.skip != 'true'
         run: |
-          cp apps/harrychang-me/README.md /tmp/README.lh.md
+          cp apps/emilychang-me/README.md /tmp/README.lh-emily.md
           git fetch origin main
           git reset --hard origin/main
-          cp /tmp/README.lh.md apps/harrychang-me/README.md
+          cp /tmp/README.lh-emily.md apps/emilychang-me/README.md
 
       - name: Commit production Lighthouse changes
         if: steps.loop_guard.outputs.skip != 'true'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore: update production lighthouse scores in README [skip ci]"
-          file_pattern: "apps/harrychang-me/README.md"
+          commit_message: "chore: update emily production lighthouse scores in README [skip ci]"
+          file_pattern: "apps/emilychang-me/README.md"
           branch: main

--- a/apps/emilychang-me/README.md
+++ b/apps/emilychang-me/README.md
@@ -1,36 +1,11 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# emilychang-me
 
-## Getting Started
+Next.js 15 portfolio app deployed at [emilychang.me](https://emilychang.me).
 
-First, run the development server:
+## Production Lighthouse
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+Audited automatically against the live deployment after every successful Vercel
+Production deploy.
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+<!-- LIGHTHOUSE_PROD_RESULTS_START -->
+<!-- LIGHTHOUSE_PROD_RESULTS_END -->


### PR DESCRIPTION
## Summary

- Production `deployment_status` events from **either** Vercel project (harrychang-me or emilychang-me) used to match harry's `lighthouse-prod` job because the `if:` only checked `startsWith('Production')`. Now that emilychang-me builds successfully on prod, every emily deploy was incorrectly triggering an audit of harrychang.me. Tighten the gate to the exact env string Vercel emits — `Production – portfolio` — so the two projects no longer collide.
- Add `lighthouse-prod-emily.yml` mirroring the same shape, gated on `Production – portfolio-monorepo-emilychang-me`. Audits `/` and `/linktree` against `https://emilychang.me` (mobile + desktop), then writes badges into `apps/emilychang-me/README.md`.
- Refactor `update-lighthouse-readme.js` to accept `--readme=<path>` so the same script serves both apps. Default unchanged.

## Loop guards

The new emily workflow uses the same two-layer guard as harry's:

1. The auto-commit message includes `[skip ci]`, which Vercel respects → no rebuild → no `deployment_status` → no re-audit.
2. Belt-and-braces: a `loop_guard` step that re-checks the deployment commit's message for `[skip ci]` or the literal commit-message string `update emily production lighthouse scores` and short-circuits the job if matched (in case `[skip ci]` ever leaks through).

The two workflows' loop-guard strings are disjoint (`update production` vs `update emily production`), so they cannot mistakenly suppress each other.

## Notes

- The dash in `Production – portfolio` is U+2013 (en-dash), not ASCII. Vercel emits it that way; the YAML files contain the en-dash literally and have an inline comment to prevent future "normalize the punctuation" edits from silently breaking the gate.
- Reuses harry's `apps/harrychang-me/.lighthouserc{,.mobile}.json` — they're generic perf configs, no need to duplicate.
- Concurrency groups are distinct (`lighthouse-prod` vs `lighthouse-prod-emily`), so a simultaneous push that triggers both does not cancel either.

## Test plan

- [ ] Merge to main and trigger an emilychang-me prod deploy; confirm only `lighthouse-prod-emily` runs (harry's job is filtered out).
- [ ] Confirm a harry prod deploy still triggers `lighthouse-prod` and not the emily workflow.
- [ ] Confirm the emily README gets a badge block under `<!-- LIGHTHOUSE_PROD_RESULTS_START -->` after the first successful emily audit.
- [ ] Confirm the auto-commit's `[skip ci]` keeps Vercel from redeploying (no audit loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated production Lighthouse audit workflow for Emily's portfolio deployment.

* **Chores**
  * Improved production Lighthouse audit script with CLI support and enhanced README integration.
  * Refined production audit workflow gating for precision triggering.
  * Updated project README with production Lighthouse results section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->