### PR TITLE
perf: reduce Vercel Edge Requests (PostHog tuning, image cache, social redirects to CDN, paper-reading static)

### DIFF
--- a/apps/harrychang-me/app/(main)/paper-reading/page.tsx
+++ b/apps/harrychang-me/app/(main)/paper-reading/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import {
   fetchArxivPapers,
   getManualPapers,
@@ -46,5 +47,12 @@ export default async function PaperReadingPage() {
     );
   }
 
-  return <PaperReadingPageClient papers={allPapers} />;
+  // Suspense boundary required because PaperReadingPageClient reads
+  // useSearchParams(); without it, Next 15 would deopt the route out of
+  // static rendering and the cache-rate fix would not land.
+  return (
+    <Suspense fallback={null}>
+      <PaperReadingPageClient papers={allPapers} />
+    </Suspense>
+  );
 }

--- a/apps/harrychang-me/app/(main)/paper-reading/page.tsx
+++ b/apps/harrychang-me/app/(main)/paper-reading/page.tsx
@@ -27,11 +27,10 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function PaperReadingPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
-}) {
+// No `searchParams` access here — pagination is handled client-side from
+// `useSearchParams()` so this page can prerender as fully static HTML and
+// be served from the CDN edge cache (avoiding per-request server work).
+export default async function PaperReadingPage() {
   // Try prebuilt cache first (build-time fetch)
   let allPapers: Paper[] = getPrebuiltPapers();
 
@@ -47,24 +46,5 @@ export default async function PaperReadingPage({
     );
   }
 
-  const pageParam = await searchParams;
-  const page = pageParam["page"] ?? "1";
-  const currentPage = Number(page);
-  const papersPerPage = 15;
-
-  const paginatedPapers = allPapers.slice(
-    (currentPage - 1) * papersPerPage,
-    currentPage * papersPerPage,
-  );
-
-  const hasPrevPage = currentPage > 1;
-  const hasNextPage = allPapers.length > currentPage * papersPerPage;
-
-  return (
-    <PaperReadingPageClient
-      paginatedPapers={paginatedPapers}
-      hasNextPage={hasNextPage}
-      hasPrevPage={hasPrevPage}
-    />
-  );
+  return <PaperReadingPageClient papers={allPapers} />;
 }

--- a/apps/harrychang-me/components/main/client-layout.tsx
+++ b/apps/harrychang-me/components/main/client-layout.tsx
@@ -3,7 +3,6 @@
 import type React from "react";
 import { Suspense } from "react";
 import Header from "@/components/header";
-import { Analytics } from "@vercel/analytics/react";
 import ClickSpark from "@portfolio/ui/ui/click-spark";
 import { useIsMobile } from "@portfolio/lib/hooks/use-mobile";
 import { LanguageProvider } from "@portfolio/lib/contexts/language-context";
@@ -46,7 +45,6 @@ export default function ClientLayout({
         <Suspense fallback={null}>
           <NotificationProvider />
         </Suspense>
-        <Analytics />
       </LanguageProvider>
     </ThemeProvider>
   );

--- a/apps/harrychang-me/components/main/paper-reading-page-client.tsx
+++ b/apps/harrychang-me/components/main/paper-reading-page-client.tsx
@@ -1,21 +1,35 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
 import { useLanguage } from "@portfolio/lib/contexts/language-context";
 import AnimatedPaperList from "@/components/main/animated-paper-list";
 import PaginationControls from "@portfolio/ui/pagination-controls";
 import { Paper } from "@portfolio/lib/types/paper";
+
+const PAPERS_PER_PAGE = 15;
+
 interface PaperReadingPageClientProps {
-  paginatedPapers: Paper[];
-  hasNextPage: boolean;
-  hasPrevPage: boolean;
+  papers: Paper[];
 }
 
 export default function PaperReadingPageClient({
-  paginatedPapers,
-  hasNextPage,
-  hasPrevPage,
+  papers,
 }: PaperReadingPageClientProps) {
   useLanguage();
+
+  const searchParams = useSearchParams();
+  const currentPage = Math.max(1, Number(searchParams.get("page")) || 1);
+
+  const { paginatedPapers, hasNextPage, hasPrevPage } = useMemo(() => {
+    const start = (currentPage - 1) * PAPERS_PER_PAGE;
+    const end = currentPage * PAPERS_PER_PAGE;
+    return {
+      paginatedPapers: papers.slice(start, end),
+      hasPrevPage: currentPage > 1,
+      hasNextPage: papers.length > end,
+    };
+  }, [papers, currentPage]);
 
   return (
     <article className="container mt-24 md:mt-32 mb-24 md:mb-32 page-transition-enter">

--- a/apps/harrychang-me/components/posthog-provider.tsx
+++ b/apps/harrychang-me/components/posthog-provider.tsx
@@ -62,8 +62,9 @@ function initPostHog() {
     ui_host: "https://us.posthog.com",
     person_profiles: "identified_only",
     capture_pageview: false,
-    capture_pageleave: true,
+    capture_pageleave: false,
     autocapture: false,
+    advanced_disable_decide: true,
     loaded: (ph) => {
       ph.register(entrySignals);
       setAnalyticsInstance(ph);

--- a/apps/harrychang-me/middleware.ts
+++ b/apps/harrychang-me/middleware.ts
@@ -1,23 +1,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { siteConfig } from "@/config/site";
 
-// Edge-resolved 308 redirects for outbound social/profile links.
-// Lives in middleware (not /app pages) so they never render — keeps these
-// throwaway hops out of Vercel RES samples and shaves the LCP/font cost.
-const SOCIAL_REDIRECTS: Record<string, string> = {
-  "/github": siteConfig.social.github,
-  "/readme": siteConfig.social.readme,
-  "/linkedin": siteConfig.social.linkedin,
-  "/instagram": siteConfig.social.instagram,
-  "/spotify": siteConfig.social.spotify,
-  "/discord": siteConfig.social.discord,
-  "/letterboxd": siteConfig.social.letterboxd,
-  "/medium": siteConfig.social.medium,
-  "/telegram": siteConfig.social.telegram,
-  "/cal": siteConfig.external.calendar,
-  "/email": `mailto:${siteConfig.author.email}`,
-};
+// Note: outbound social/profile redirects (/github, /linkedin, /instagram,
+// /spotify, /discord, /letterboxd, /medium, /telegram, /cal, /email, /readme)
+// are handled by next.config.mjs `redirects()` so they're served at the CDN
+// edge as 308s without invoking the middleware function.
 
 export function middleware(request: NextRequest) {
   const url = request.nextUrl;
@@ -104,15 +91,6 @@ export function middleware(request: NextRequest) {
     // Rewrite to lab routes (only for page routes)
     url.pathname = `/lab${url.pathname}`;
     return NextResponse.rewrite(url);
-  }
-
-  // Outbound social/profile redirects on the main domain. Skipped on lab so
-  // /lab/<path> routing is unaffected.
-  if (!isLab) {
-    const target = SOCIAL_REDIRECTS[url.pathname];
-    if (target) {
-      return NextResponse.redirect(new URL(target), 308);
-    }
   }
 
   // Prevent accessing lab routes from main domain in production

--- a/apps/harrychang-me/next.config.mjs
+++ b/apps/harrychang-me/next.config.mjs
@@ -113,18 +113,23 @@ const nextConfig = {
           },
         ],
       },
-      {
-        // Favicon/icon/manifest assets: stable filenames, rarely change.
-        // Browser-cache aggressively to keep returning-visitor traffic off
-        // the Edge Request meter. Bump filenames to bust if ever swapped.
-        source: '/(favicon.ico|apple-icon.png|chinese_name_icon.png|site.webmanifest)',
+      // Favicon/icon/manifest assets: stable filenames, rarely change.
+      // Browser-cache aggressively to keep returning-visitor traffic off
+      // the Edge Request meter. Bump filenames to bust if ever swapped.
+      ...[
+        '/favicon.ico',
+        '/apple-icon.png',
+        '/chinese_name_icon.png',
+        '/site.webmanifest',
+      ].map((source) => ({
+        source,
         headers: [
           {
             key: 'Cache-Control',
             value: 'public, max-age=31536000, immutable',
           },
         ],
-      },
+      })),
     ]
   },
   async redirects() {

--- a/apps/harrychang-me/next.config.mjs
+++ b/apps/harrychang-me/next.config.mjs
@@ -3,6 +3,24 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+// Outbound social/profile redirects, kept in sync with config/site.ts.
+// Defined here (not in middleware) so Vercel serves them as 308s straight
+// from the CDN edge — no function invocation, no middleware traversal.
+// TODO: codegen from config/site.ts to prevent drift
+const SOCIAL_REDIRECTS = [
+  ['/github', 'https://github.com/Harrychangtw'],
+  ['/readme', 'https://github.com/Harrychangtw/portfolio-monorepo/tree/main/apps/harrychang-me'],
+  ['/linkedin', 'https://www.linkedin.com/in/chi-wei-chang-928408375/'],
+  ['/instagram', 'https://www.instagram.com/pomelo_chang_08/'],
+  ['/spotify', 'https://open.spotify.com/user/1b7kc6j0zerk49mrv80pwdd96?si=7d5a6e1a4fa34de3'],
+  ['/discord', 'https://discord.com/users/836567989209661481'],
+  ['/letterboxd', 'https://boxd.it/fSKuF'],
+  ['/medium', 'https://medium.com/@chiwei_chang'],
+  ['/telegram', 'https://t.me/harrychangtw'],
+  ['/cal', 'https://calendar.notion.so/meet/harry-chang/ybit2gkx'],
+  ['/email', 'mailto:chiwei@harrychang.me'],
+]
+
 let userConfig = undefined
 
 
@@ -83,7 +101,38 @@ const nextConfig = {
           },
         ],
       },
+      {
+        // Pre-built optimized images at fixed paths. URL must change if
+        // contents change (e.g. rename the file or add a version suffix)
+        // since `immutable` tells browsers never to revalidate.
+        source: '/images/optimized/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        // Favicon/icon/manifest assets: stable filenames, rarely change.
+        // Browser-cache aggressively to keep returning-visitor traffic off
+        // the Edge Request meter. Bump filenames to bust if ever swapped.
+        source: '/(favicon.ico|apple-icon.png|chinese_name_icon.png|site.webmanifest)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
     ]
+  },
+  async redirects() {
+    return SOCIAL_REDIRECTS.map(([source, destination]) => ({
+      source,
+      destination,
+      permanent: true,
+    }))
   },
   experimental: {
     webpackBuildWorker: true,

--- a/packages/lib/hooks/use-now-playing.ts
+++ b/packages/lib/hooks/use-now-playing.ts
@@ -59,10 +59,16 @@ export function useNowPlaying(
       }
     };
 
-    load();
-    startTimer();
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", onVisibility);
+      // Tabs opened in the background should not poll until focused.
+      if (!document.hidden) {
+        load();
+        startTimer();
+      }
+    } else {
+      load();
+      startTimer();
     }
 
     return () => {

--- a/packages/lib/hooks/use-now-playing.ts
+++ b/packages/lib/hooks/use-now-playing.ts
@@ -7,7 +7,7 @@ type UseNowPlayingOptions = {
 };
 
 export function useNowPlaying(
-  pollIntervalMs = 20000,
+  pollIntervalMs = 60000,
   opts?: UseNowPlayingOptions,
 ) {
   const fresh = Boolean(opts?.fresh);
@@ -27,7 +27,6 @@ export function useNowPlaying(
           ? "/api/spotify/now-playing?fresh=1"
           : "/api/spotify/now-playing";
         const res = await fetch(url, {
-          cache: "no-store",
           signal: controller.signal,
         });
         const json = await res.json();
@@ -41,12 +40,37 @@ export function useNowPlaying(
       }
     };
 
+    const startTimer = () => {
+      if (timer !== undefined) return;
+      timer = window.setInterval(load, pollIntervalMs);
+    };
+    const stopTimer = () => {
+      if (timer !== undefined) {
+        window.clearInterval(timer);
+        timer = undefined;
+      }
+    };
+    const onVisibility = () => {
+      if (document.hidden) {
+        stopTimer();
+      } else {
+        load();
+        startTimer();
+      }
+    };
+
     load();
-    timer = window.setInterval(load, pollIntervalMs);
+    startTimer();
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibility);
+    }
 
     return () => {
       canceled = true;
-      if (timer) window.clearInterval(timer);
+      stopTimer();
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibility);
+      }
       controller?.abort();
     };
   }, [pollIntervalMs, fresh]);


### PR DESCRIPTION
## Summary

Free-tier Vercel deployment hit 75% of its 1M Edge Request quota with only ~611 visitors and ~7.5K real pageviews — a ~100:1 ratio of edge requests to pageviews. Investigation surfaced five distinct multipliers driving the disparity: (1) PostHog firing `$pageleave` and `/decide` calls on top of every `$pageview` through the `/ingest/*` reverse proxy, (2) the Spotify now-playing poller running every 20s with `cache: "no-store"` on every page including hidden/abandoned tabs, (3) social redirect routes (`/github`, `/linkedin`, etc.) being resolved by the middleware function on every hit, (4) `/paper-reading` opting itself out of static rendering by `await`ing `searchParams`, and (5) favicon/icon/manifest assets served with no browser-cache headers, forcing every navigation to re-fetch them. This PR addresses all five.

## Changes

**Analytics**
- `components/posthog-provider.tsx`: set `capture_pageleave: false` and `advanced_disable_decide: true`. `$pageview` still fires on cold load and on every route change.
- `components/main/client-layout.tsx`: removed `<Analytics />` from `@vercel/analytics`. `<SpeedInsights />` left intact at `app/(main)/layout.tsx:85` (RES depends on it). Package not removed from monorepo deps because `apps/emilychang-me` still uses it.

**Caching**
- `next.config.mjs`: added `Cache-Control: public, max-age=31536000, immutable` for `/images/optimized/:path*` and for `/favicon.ico`, `/apple-icon.png`, `/chinese_name_icon.png`, `/site.webmanifest`. Filenames must change to bust cache (since `immutable` skips revalidation).

**Redirects**
- `middleware.ts`: removed the `SOCIAL_REDIRECTS` table and the `if (!isLab) { ... }` block that resolved them. Replaced with a comment pointing at `next.config.mjs`.
- `next.config.mjs`: added `redirects()` returning `permanent: true` (308) entries for `/github`, `/readme`, `/linkedin`, `/instagram`, `/spotify`, `/discord`, `/letterboxd`, `/medium`, `/telegram`, `/cal`, `/email`. Vercel serves these directly from the CDN edge with no function invocation.

**/paper-reading static rendering**
- `app/(main)/paper-reading/page.tsx`: removed the `searchParams` parameter and all server-side slicing. Now passes the full `allPapers` array to the client component. With no dynamic API access, the route prerenders to static HTML at build time.
- `components/main/paper-reading-page-client.tsx`: now reads `currentPage` via `useSearchParams()` and slices the papers array client-side with `useMemo()`. `<PaginationControls>` is unchanged — it already uses `router.push(?page=N)` for navigation.

**Spotify polling**
- `packages/lib/hooks/use-now-playing.ts`: default poll interval 20s → 60s, removed `cache: "no-store"` so the API's `s-maxage=60` edge cache can be honored, added `visibilitychange` listener that stops the timer when the tab is hidden and resumes (with an immediate refetch) on focus.

## Expected impact

- **PostHog tuning** — eliminates `/ingest/decide` (1 request per cold load) and `/ingest/e?...&event=$pageleave` (1 request per pageview). Roughly halves PostHog edge traffic.
- **Vercel Web Analytics removed** — removes `/_vercel/insights/script.js` + `/_vercel/insights/view` (top of the offender list at 7.7K + 2K hits respectively, ~10K total). Speed Insights remains for Real Experience Score.
- **Image / favicon / manifest cache** — once a returning visitor has them, the browser serves locally for a year. Eliminates re-fetches across navigations within and across sessions.
- **Social redirects → CDN 308** — observed top-50 traffic for these routes was ~16K combined hits (`/instagram` 1.7K + `/linkedin` 1.7K + `/github` 1.7K + `/email` 1.7K + `/cal` 1.7K + `/discord` 1.5K + `/telegram` 1.5K + `/spotify` 1.4K + `/medium` 1.4K + `/letterboxd` 1.4K). All now resolved at the edge with no middleware function invocation. Edge Request count for these routes still increments by 1 per hit, but middleware execution time and any cascading rewrites are removed.
- **/paper-reading static** — was 1.8K hits at 0% cache. Should jump to ~99% (matching `/uses` and `/cv` at 97.5%). Client gets a 41 KB gzipped JSON once per cold load instead of paying a server round-trip on every paginate.
- **Spotify poller** — biggest expected win. Was firing every 20s on every tab indefinitely, even when hidden. Now: 60s interval, paused on hidden tabs. Idle/abandoned tabs (the long tail) drop from a constant trickle to zero.

## Verification

After deploy, manually confirm:
- [ ] PostHog: open a page, check Network tab — `$pageview` event POSTs to `/ingest/...`, no `$pageleave` requests fire on navigation, no `/ingest/decide` request on load.
- [ ] Speed Insights: `window` console — `/_vercel/speed-insights/script.js` loads, no console errors.
- [ ] Social redirects: `curl -I https://www.harrychang.me/github` returns `308` with `Location: https://github.com/Harrychangtw`. Spot-check `/linkedin`, `/email` (mailto:), `/cal`.
- [ ] /paper-reading: navigate to `/paper-reading?page=2` — pagination updates without a network round-trip (no document fetch in Network tab beyond the initial page).
- [ ] Image cache headers: `curl -I https://www.harrychang.me/images/optimized/<some-path>.webp` and `curl -I https://www.harrychang.me/favicon.ico` both return `Cache-Control: public, max-age=31536000, immutable`.
- [ ] Spotify polling: open footer, watch Network — request to `/api/spotify/now-playing` repeats every ~60s, stops when tab is hidden, resumes immediately on focus.

## Known follow-ups

- **SOCIAL_REDIRECTS drift risk** — URLs are hardcoded into `next.config.mjs` because `.mjs` cannot import the `.ts` site config without a TS loader. A `// TODO: codegen from config/site.ts to prevent drift` is in place. If `config/site.ts` is updated, `next.config.mjs` must be updated in lockstep.
- **/paper-reading bot traffic** — still ~1.8K hits/period, mostly bots. Now cheap (static HTML from CDN), but if bot volume grows, consider crawler restrictions in `robots.txt`.
- **/404 bot traffic** — 1.8K hits at 100% cache, almost entirely scanner bots probing for vulnerabilities. Worth a separate `robots.txt` PR with `Disallow` entries for the worst offenders (GPTBot, ClaudeBot, CCBot, PerplexityBot, etc.) if you don't want their traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Paper reading pages now rendered as static content for faster loading and caching.
  * Social redirects now handled at CDN edge for faster response times.
  * Music player polling optimized to reduce bandwidth usage.

* **Enhancements**
  * Music player pauses polling when browser tab is inactive.

* **Changes**
  * Analytics component removed from main layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->