### PR TITLE
fix(ui): restore priority image LCP bypass — RES regression fix

### DIFF
--- a/packages/ui/image-container.tsx
+++ b/packages/ui/image-container.tsx
@@ -148,31 +148,35 @@ export function ImageContainer({
               ></div>
             )}
 
-            {/* Blurred thumbnail placeholder — fades out once full image is ready */}
-            {!isVideo && thumbnailSrc && (isVisible || priority) && (
-              <div
-                className={`absolute inset-0 z-[5] pointer-events-none transition-opacity duration-500 ${
-                  blurComplete ? "opacity-0" : "opacity-100"
-                }`}
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={thumbnailSrc}
-                  alt=""
-                  className={`w-full h-full ${
-                    noInsetPadding ? "object-cover" : "object-contain"
-                  } object-center`}
-                  style={
-                    noInsetPadding
-                      ? { filter: "blur(20px)", transform: "scale(1.5)" }
-                      : undefined
-                  }
-                />
-              </div>
-            )}
+            {!priority && (
+              <>
+                {/* Blurred thumbnail placeholder — fades out once full image is ready */}
+                {!isVideo && thumbnailSrc && isVisible && (
+                  <div
+                    className={`absolute inset-0 z-[5] pointer-events-none transition-opacity duration-500 ${
+                      blurComplete ? "opacity-0" : "opacity-100"
+                    }`}
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={thumbnailSrc}
+                      alt=""
+                      className={`w-full h-full ${
+                        noInsetPadding ? "object-cover" : "object-contain"
+                      } object-center`}
+                      style={
+                        noInsetPadding
+                          ? { filter: "blur(20px)", transform: "scale(1.5)" }
+                          : undefined
+                      }
+                    />
+                  </div>
+                )}
 
-            {/* Loading skeleton text overlay */}
-            <ImageLoadingSkeleton visible={!blurComplete} />
+                {/* Loading skeleton text overlay */}
+                <ImageLoadingSkeleton visible={!blurComplete} />
+              </>
+            )}
 
             <div className="absolute inset-0 z-0">
               {(isVisible || priority) && (
@@ -197,8 +201,8 @@ export function ImageContainer({
                       alt={alt}
                       fill
                       priority={priority}
-                      className={`${noInsetPadding ? "object-cover" : "object-contain"} object-center transition-opacity duration-500 ${
-                        blurComplete ? "opacity-100" : "opacity-0"
+                      className={`${noInsetPadding ? "object-cover" : "object-contain"} object-center ${priority ? "" : "transition-opacity duration-500"} ${
+                        blurComplete || priority ? "opacity-100" : "opacity-0"
                       } ${imgClassName || ""}`}
                       sizes={sizes}
                       quality={quality}


### PR DESCRIPTION
## Summary
- Priority `<Image>` now skips the `transition-opacity duration-500` class and renders at `opacity-100` immediately, so its first paint is the LCP candidate.
- Blur thumbnail + `ImageLoadingSkeleton` are gated behind `!priority` so they don't render an overlay that competes with the LCP paint on hero images.
- Non-priority images keep the unified blur-up flow (no behavior change).

## Investigation Context

**Symptom:** RES (Real Experience Score) dropped to the 55–60 band on `/`, `/projects/[slug]`, and `/blog/[slug]` while `/gallery/[slug]`, `/design`, and `/projects` (index) stayed at 92–100.

**Cause:** Two commits to `packages/ui/image-container.tsx` interacted badly:

1. **`179feef` (2026-05-01)** removed the priority short-circuit on the `<Image>` className. Before this commit, priority images skipped the opacity-0 fade-in entirely (`blurComplete || priority ? "opacity-100" : "opacity-0"`). After it, every image — priority or not — starts at `opacity: 0` and only fades in over 500ms once React state flips `blurComplete=true` from `onLoad`.
2. **`8d6297b` (2026-05-03)** correctly forwarded the `priority` prop to `<Image>` and flipped hero call sites from `priority={false}` to `priority={true}`. By itself a correctness fix — but combined with `179feef`, heroes now eagerly fetch *and* paint at opacity-0 until the state-driven fade.

**Why LCP regresses:** browsers' LCP algorithm ignores elements with `opacity: 0`. The hero `<Image>` no longer registers as the LCP candidate when Next.js finishes streaming the image bytes — the LCP timestamp slides forward to whenever React commits `setBlurComplete(true)` *and* the 500ms CSS transition crosses the alpha-detect threshold. Hydration + state commit + transition adds 1–2s on field hardware.

**Why the route pattern fits:** routes with a large above-the-fold `ImageContainer` hero (`/`, `/projects/[slug]`, `/blog/[slug]`) regress; routes whose LCP candidate is a text node (`/design`, `/projects` index) are unaffected; `/gallery/[slug]` stays good because its hero is smaller / below fold and the LCP candidate is plausibly text.

**Fix (Option A from the investigation):** restore the priority short-circuit so priority images render at `opacity-100` immediately and skip both the transition class and the blur/skeleton overlay. Non-priority images keep the unified blur-up flow. Does **not** revert `179feef` or `8d6297b` wholesale — `179feef` legitimately removed a progressive-WebP scanline on grid cards, and `8d6297b` fixed a silent prop bug.

Full investigation: `perf-degradation-investigation.md` → "Follow-up: PR #66 Diff Analysis" → "Suggested scoped fix" (Option A). All three hero call sites in `blog-post-client.tsx`, `project-post-client.tsx`, `gallery-post-client.tsx` already pass `priority={true}` (from 8d6297b), so no call-site changes were needed.

## Test plan
- [x] `pnpm build` succeeds (no type errors)
- [ ] Preview deploy + re-run Speed Insights for 48 h on `/`, `/projects/[slug]`, `/blog/[slug]` to confirm RES recovers to the 90+ band before merge
- [ ] Verify non-priority `ImageContainer` instances (grid cards, in-body images) still blur-up as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Priority images now load and display immediately without loading overlays or placeholder effects.
  * Standard-priority images show placeholders only when visible in the viewport.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harrychangtw/portfolio-monorepo/pull/71)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->