### PR TITLE
fix(ui): hub OG images, /design NextUpCard, and gallery skeleton CLS

### DIFF
--- a/apps/harrychang-me/components/graph/embedded-graph.tsx
+++ b/apps/harrychang-me/components/graph/embedded-graph.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from "@portfolio/lib/contexts/language-context";
 import { useIsMobile } from "@portfolio/lib/hooks/use-mobile";
 import GraphCanvas from "./graph-canvas";
 import type { GraphData, GraphNode } from "./types";
+import { resolveHubImageUrl } from "./graph-utils";
 import { track, events } from "@portfolio/lib/analytics";
 
 export interface EmbeddedNodeInfo {
@@ -21,24 +22,12 @@ export interface EmbeddedNodeInfo {
   nodeType?: string;
 }
 
-/** OG images shown when hovering over a hub node in the embedded graph */
-const HUB_OG_IMAGES: Record<string, string> = {
-  root: "/images/og-image.webp",
-  post: "/images/og-image-blog.webp",
-  project: "/images/og-image-projects.webp",
-  gallery: "/images/og-image-gallery.webp",
-  about: "/images/og-image.webp",
-  updates: "/images/og-image.webp",
-  uses: "/images/og-image-uses.webp",
-  linktree: "/images/og-image.webp",
-  cv: "/images/og-image-resume.webp",
-  reading: "/images/og-image-reading.webp",
-};
-
 interface EmbeddedGraphProps {
   /** Slug of the focal (next-up) file node to center & select */
   focalSlug?: string;
   focalSourceType?: "post" | "project" | "gallery";
+  /** Slug of a hub node to center & select (used on non-content pages like /design) */
+  focalHubSlug?: string;
   onNodeHover?: (node: EmbeddedNodeInfo | null) => void;
   /** Mobile crosshair centre-node callback */
   onCenterNodeChange?: (node: EmbeddedNodeInfo | null) => void;
@@ -66,17 +55,12 @@ async function loadGraphData(): Promise<GraphData | null> {
 }
 
 function toInfo(node: GraphNode): EmbeddedNodeInfo {
-  // Hub nodes don't carry content images — use pre-defined OG images instead.
-  const imageUrl =
-    node.nodeType === "hub"
-      ? (HUB_OG_IMAGES[node.sourceSlug] ?? node.imageUrl)
-      : node.imageUrl;
   return {
     title: node.title,
     slug: node.sourceSlug,
     sourceType: node.sourceType,
     url: node.url,
-    imageUrl,
+    imageUrl: resolveHubImageUrl(node),
     description: node.description || node.snippet,
     tldr: node.tldr,
     nodeType: node.nodeType,
@@ -91,6 +75,7 @@ function toInfo(node: GraphNode): EmbeddedNodeInfo {
 export default function EmbeddedGraph({
   focalSlug,
   focalSourceType,
+  focalHubSlug,
   onNodeHover,
   onCenterNodeChange,
 }: EmbeddedGraphProps) {
@@ -125,7 +110,17 @@ export default function EmbeddedGraph({
 
   // Resolve focal node id in the filtered set.
   const focalNodeId = useMemo(() => {
-    if (!filteredData || !focalSlug || !focalSourceType) return undefined;
+    if (!filteredData) return undefined;
+    // Hub focal takes precedence when set (used on non-content pages)
+    if (focalHubSlug) {
+      return filteredData.nodes.find(
+        (n) =>
+          n.nodeType === "hub" &&
+          n.sourceSlug === focalHubSlug &&
+          n.locale === locale,
+      )?.id;
+    }
+    if (!focalSlug || !focalSourceType) return undefined;
     return filteredData.nodes.find(
       (n) =>
         n.nodeType === "file" &&
@@ -133,7 +128,7 @@ export default function EmbeddedGraph({
         n.sourceType === focalSourceType &&
         n.locale === locale,
     )?.id;
-  }, [filteredData, focalSlug, focalSourceType, locale]);
+  }, [filteredData, focalSlug, focalSourceType, focalHubSlug, locale]);
 
   const { startNavigation } = useNavigation();
 

--- a/apps/harrychang-me/components/graph/graph-next-up.tsx
+++ b/apps/harrychang-me/components/graph/graph-next-up.tsx
@@ -68,7 +68,8 @@ export default function GraphNextUp({
 
   // "base" card = the default/selected node data (starts as nextItem or hub default)
   const [baseCard, setBaseCard] = useState<NextUpItem | null>(initialCard);
-  const [baseCardPath] = useState<BasePath>(basePath ?? "blog");
+  const baseCardPath: BasePath =
+    basePath ?? (sourceType ? sourceTypeToBasePath(sourceType) : "blog");
 
   // "hover" card = temporary override while hovering a node
   const [hoverCard, setHoverCard] = useState<{

--- a/apps/harrychang-me/components/graph/graph-next-up.tsx
+++ b/apps/harrychang-me/components/graph/graph-next-up.tsx
@@ -15,14 +15,22 @@ interface NextUpItem {
   aspectRatio?: number;
   /** Direct href for hub nodes whose route doesn't fit /{basePath}/{slug}. */
   href?: string;
+  /** Image is not in the optimization pipeline (e.g. OG images for hub nodes). */
+  rawImage?: boolean;
 }
 
 type BasePath = "blog" | "projects" | "gallery";
 
 interface GraphNextUpProps {
-  sourceType: "post" | "project" | "gallery";
-  basePath: BasePath;
+  sourceType?: "post" | "project" | "gallery";
+  basePath?: BasePath;
   nextItem?: NextUpItem | null;
+  /** Hub slug to center on and show as the default card (for non-content pages). */
+  defaultHubSlug?: string;
+  /** Default card to display synchronously when using defaultHubSlug (avoids CLS). */
+  defaultHubCard?: NextUpItem;
+  /** Override the outer wrapper className (default includes top margin). */
+  className?: string;
 }
 
 function sourceTypeToBasePath(st: string): BasePath {
@@ -42,17 +50,25 @@ function normalizeImageUrl(url: string | null | undefined): string {
  * Combined graph + NextUpCard component.
  * The graph default-selects the next item's node. Hovering a file node
  * temporarily updates the NextUpCard; leaving reverts to the selected node.
+ *
+ * For non-content pages (e.g. /design), pass `defaultHubSlug` and
+ * `defaultHubCard` to center the graph on a hub node and show a default card.
  */
 export default function GraphNextUp({
   sourceType,
   basePath,
   nextItem,
+  defaultHubSlug,
+  defaultHubCard,
+  className,
 }: GraphNextUpProps) {
   const { language, t } = useLanguage();
 
-  // "base" card = the default/selected node data (starts as nextItem)
-  const [baseCard, setBaseCard] = useState<NextUpItem | null>(nextItem ?? null);
-  const [baseCardPath] = useState<BasePath>(basePath);
+  const initialCard = nextItem ?? defaultHubCard ?? null;
+
+  // "base" card = the default/selected node data (starts as nextItem or hub default)
+  const [baseCard, setBaseCard] = useState<NextUpItem | null>(initialCard);
+  const [baseCardPath] = useState<BasePath>(basePath ?? "blog");
 
   // "hover" card = temporary override while hovering a node
   const [hoverCard, setHoverCard] = useState<{
@@ -69,15 +85,15 @@ export default function GraphNextUp({
   // Reset derived state when nextItem changes (e.g. client-side navigation)
   /* eslint-disable react-hooks/set-state-in-effect -- synchronising derived state from prop change */
   useEffect(() => {
-    setBaseCard(nextItem ?? null);
+    setBaseCard(nextItem ?? defaultHubCard ?? null);
     setLocalizedNextItem(nextItem ?? null);
     setHoverCard(null);
     isDefaultRef.current = true;
-  }, [nextItem]);
+  }, [nextItem, defaultHubCard]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
   useEffect(() => {
-    if (!nextItem) return;
+    if (!nextItem || !basePath) return;
 
     async function fetchLocalized() {
       const baseSlug = nextItem!.slug.replace("_zh-tw", "");
@@ -156,8 +172,8 @@ export default function GraphNextUp({
         title: node.title,
         category: node.tldr || node.description || "",
         imageUrl: normalizeImageUrl(node.imageUrl),
-        // Hub nodes link to their own route directly (e.g. /blog, /gallery)
         href: isHub ? node.url : undefined,
+        rawImage: isHub,
       },
       basePath: sourceTypeToBasePath(node.sourceType),
     });
@@ -178,6 +194,7 @@ export default function GraphNextUp({
           category: node.tldr || node.description || "",
           imageUrl: normalizeImageUrl(node.imageUrl),
           href: isHub ? node.url : undefined,
+          rawImage: isHub,
         },
         basePath: sourceTypeToBasePath(node.sourceType),
       });
@@ -190,7 +207,7 @@ export default function GraphNextUp({
   const displayBasePath = hoverCard ? hoverCard.basePath : baseCardPath;
 
   return (
-    <div className="w-full mt-8 md:mt-12">
+    <div className={className ?? "w-full mt-8 md:mt-12"}>
       {/* Single bordered container: 3:2 graph + NextUpCard stacked inside */}
       <div className="relative border border-border bg-card overflow-hidden">
         {/* Graph — strictly 3:2 */}
@@ -207,14 +224,15 @@ export default function GraphNextUp({
           <EmbeddedGraph
             focalSlug={nextItem?.slug?.replace(/_zh-tw|_zh-TW/i, "")}
             focalSourceType={sourceType}
+            focalHubSlug={defaultHubSlug}
             onNodeHover={handleNodeHover}
             onCenterNodeChange={handleCenterNodeChange}
           />
         </div>
 
-        {/* NextUpCard — inside the same container, below the graph */}
-        {displayCard && (
-          <div className="border-t border-border">
+        {/* NextUpCard — always rendered to avoid CLS; content swaps on hover */}
+        <div className="border-t border-border">
+          {displayCard ? (
             <NextUpCard
               title={displayCard.title}
               category={displayCard.category}
@@ -223,9 +241,14 @@ export default function GraphNextUp({
               basePath={displayBasePath}
               aspectRatio={displayCard.aspectRatio}
               href={displayCard.href}
+              rawImage={displayCard.rawImage}
             />
-          </div>
-        )}
+          ) : (
+            <div className="p-4 md:p-6">
+              <div className="h-5 w-24 bg-muted/40 rounded animate-pulse" />
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/harrychang-me/components/graph/graph-utils.ts
+++ b/apps/harrychang-me/components/graph/graph-utils.ts
@@ -1,5 +1,28 @@
 import type { GraphNode, NodeType, SourceType } from "./types";
 
+/* ─── Hub OG images (shared across embedded graph, preview cards, etc.) ──── */
+
+export const HUB_OG_IMAGES: Record<string, string> = {
+  root: "/images/og-image.webp",
+  post: "/images/og-image-blog.webp",
+  project: "/images/og-image-projects.webp",
+  gallery: "/images/og-image-gallery.webp",
+  about: "/images/og-image.webp",
+  updates: "/images/og-image.webp",
+  uses: "/images/og-image-uses.webp",
+  linktree: "/images/og-image.webp",
+  cv: "/images/og-image-resume.webp",
+  reading: "/images/og-image-reading.webp",
+  design: "/images/og-image-design.webp",
+};
+
+export function resolveHubImageUrl(node: GraphNode): string | null {
+  if (node.nodeType === "hub") {
+    return HUB_OG_IMAGES[node.sourceSlug] ?? node.imageUrl ?? null;
+  }
+  return node.imageUrl ?? null;
+}
+
 /* ─── Color helpers ────────────────────────────────────────────────────────── */
 
 export const SOURCE_TYPE_CSS_VAR: Record<SourceType, string> = {

--- a/apps/harrychang-me/components/graph/mobile-node-card.tsx
+++ b/apps/harrychang-me/components/graph/mobile-node-card.tsx
@@ -5,6 +5,7 @@ import { ImageContainer } from "@portfolio/ui/image-container";
 import NavigationLink from "@portfolio/ui/navigation-link";
 import NextUpCard from "@portfolio/ui/next-up-card";
 import type { GraphNode, SourceType } from "./types";
+import { resolveHubImageUrl } from "./graph-utils";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -240,7 +241,9 @@ export default function MobileNodeCard({ node }: MobileNodeCardProps) {
                     : node.description || node.snippet)
                 }
                 slug={node.sourceSlug}
-                imageUrl={isTag ? "" : normalizeImageUrl(node.imageUrl)}
+                imageUrl={
+                  isTag ? "" : normalizeImageUrl(resolveHubImageUrl(node))
+                }
                 basePath={sourceTypeToBasePath(node.sourceType as SourceType)}
                 label={null}
                 href={
@@ -251,6 +254,7 @@ export default function MobileNodeCard({ node }: MobileNodeCardProps) {
                     : undefined
                 }
                 disableLink={isTag || !node.url}
+                rawImage={isHub}
               />
             </div>
           )}

--- a/apps/harrychang-me/components/graph/node-preview-card.tsx
+++ b/apps/harrychang-me/components/graph/node-preview-card.tsx
@@ -3,6 +3,7 @@
 import { motion } from "motion/react";
 import { ImageContainer } from "@portfolio/ui/image-container";
 import type { GraphNode, SourceType, NodeType } from "./types";
+import { resolveHubImageUrl } from "./graph-utils";
 
 const sourceLabels: Record<SourceType, string> = {
   post: "Blog Post",
@@ -54,13 +55,14 @@ export default function NodePreviewCard({
     p.startsWith("http") ? p : p.startsWith("/") ? p : `/${p}`;
 
   // Determine image source for the 3:2 preview
+  const resolvedImageUrl = resolveHubImageUrl(node);
   const imageSrc =
     isImage && node.mediaSource
       ? normalizePath(node.mediaSource)
       : isVideo && youtubeId
         ? `https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`
-        : node.imageUrl
-          ? normalizePath(node.imageUrl)
+        : resolvedImageUrl
+          ? normalizePath(resolvedImageUrl)
           : null;
 
   const hasImage = !!imageSrc && !isTag;
@@ -101,6 +103,7 @@ export default function NodePreviewCard({
                 quality={60}
                 sizes="280px"
                 imgClassName="object-cover"
+                rawImage={node.nodeType === "hub"}
               />
             )}
 

--- a/apps/harrychang-me/components/main/typography-page-client.tsx
+++ b/apps/harrychang-me/components/main/typography-page-client.tsx
@@ -233,6 +233,7 @@ export default function TypographyPageClient() {
               alt="Harry Chang Portfolio Identity — The Tower of Babel"
               aspectRatio={1.5}
               noInsetPadding={true}
+              sizes="(min-width: 768px) 50vw, 100vw"
             />
           </NavigationLink>
           <div className="grid grid-cols-2 gap-2">
@@ -245,6 +246,7 @@ export default function TypographyPageClient() {
                 alt="Blog: The Astronomer"
                 aspectRatio={1200 / 630}
                 noInsetPadding={true}
+                sizes="(min-width: 768px) 25vw, 50vw"
               />
             </NavigationLink>
             <NavigationLink
@@ -256,6 +258,7 @@ export default function TypographyPageClient() {
                 alt="Gallery: The Art of Painting"
                 aspectRatio={1200 / 630}
                 noInsetPadding={true}
+                sizes="(min-width: 768px) 25vw, 50vw"
               />
             </NavigationLink>
             <a
@@ -269,6 +272,7 @@ export default function TypographyPageClient() {
                 alt="Lab: The Fall of Icarus"
                 aspectRatio={1200 / 630}
                 noInsetPadding={true}
+                sizes="(min-width: 768px) 25vw, 50vw"
               />
             </a>
             <NavigationLink
@@ -280,6 +284,7 @@ export default function TypographyPageClient() {
                 alt="Projects: The Forge of Vulcan"
                 aspectRatio={1200 / 630}
                 noInsetPadding={true}
+                sizes="(min-width: 768px) 25vw, 50vw"
               />
             </NavigationLink>
             <NavigationLink
@@ -291,6 +296,7 @@ export default function TypographyPageClient() {
                 alt="Design System"
                 aspectRatio={1200 / 630}
                 noInsetPadding={true}
+                sizes="(min-width: 768px) 25vw, 50vw"
               />
             </NavigationLink>
             <NavigationLink
@@ -302,6 +308,7 @@ export default function TypographyPageClient() {
                 alt="Manifesto"
                 aspectRatio={1200 / 630}
                 noInsetPadding={true}
+                sizes="(min-width: 768px) 25vw, 50vw"
               />
             </NavigationLink>
             <NavigationLink
@@ -313,6 +320,7 @@ export default function TypographyPageClient() {
                 alt="Paper Reading"
                 aspectRatio={1200 / 630}
                 noInsetPadding={true}
+                sizes="(min-width: 768px) 25vw, 50vw"
               />
             </NavigationLink>
             <NavigationLink
@@ -324,6 +332,7 @@ export default function TypographyPageClient() {
                 alt="Uses & Setup"
                 aspectRatio={1200 / 630}
                 noInsetPadding={true}
+                sizes="(min-width: 768px) 25vw, 50vw"
               />
             </NavigationLink>
           </div>

--- a/apps/harrychang-me/components/main/typography-page-client.tsx
+++ b/apps/harrychang-me/components/main/typography-page-client.tsx
@@ -453,7 +453,6 @@ export default function TypographyPageClient() {
         title={t("design.motionInteraction")}
         description={<p>{t("design.motionDesc")}</p>}
       >
-        {" "}
         <div className="space-y-0">
           {[
             {

--- a/apps/harrychang-me/components/main/typography-page-client.tsx
+++ b/apps/harrychang-me/components/main/typography-page-client.tsx
@@ -7,7 +7,7 @@ import { getAllFontFamilies } from "@portfolio/lib/lib/typography";
 import { useLanguage } from "@portfolio/lib/contexts/language-context";
 import { ImageContainer } from "@portfolio/ui/image-container";
 import NavigationLink from "@portfolio/ui/navigation-link";
-import EmbeddedGraph from "@/components/graph/local-graph-dynamic";
+import GraphNextUp from "@/components/graph/graph-next-up";
 
 /* ── Helpers ──────────────────────────────────────────────── */
 
@@ -136,6 +136,13 @@ function SectionSplit({
 export default function TypographyPageClient() {
   const { t } = useLanguage();
   const fonts = getAllFontFamilies();
+
+  /* ── Font descriptions ──────────────────────────────────── */
+
+  const fontDescriptions: Record<string, string | undefined> = {
+    "IBM Plex Sans": t("design.fontDescIbmPlex"),
+    Artific: t("design.fontDescArtific"),
+  };
 
   /* ── Color palette data ─────────────────────────────────── */
 
@@ -324,7 +331,11 @@ export default function TypographyPageClient() {
       </SectionSplit>
 
       {/* 02 — Color Palette */}
-      <Section index={2} title={t("design.colorPalette")}>
+      <SectionSplit
+        index={2}
+        title={t("design.colorPalette")}
+        description={<p>{t("design.colorPaletteDesc")}</p>}
+      >
         <div className="grid grid-cols-4 gap-2">
           {colorPalette.map((color) => (
             <ColorCard
@@ -334,10 +345,14 @@ export default function TypographyPageClient() {
             />
           ))}
         </div>
-      </Section>
+      </SectionSplit>
 
       {/* 03 — Type Scale */}
-      <Section index={3} title={t("design.typeScale")}>
+      <SectionSplit
+        index={3}
+        title={t("design.typeScale")}
+        description={<p>{t("design.typeScaleDesc")}</p>}
+      >
         <div className="space-y-0">
           {typeScale.map((level, i) => (
             <div
@@ -357,17 +372,30 @@ export default function TypographyPageClient() {
             </div>
           ))}
         </div>
-      </Section>
+      </SectionSplit>
 
       {/* 04+ — Font Specimens */}
       {fonts.map((font, i) => (
-        <Section key={font.name} index={fontStartIndex + i} title={font.name}>
+        <SectionSplit
+          key={font.name}
+          index={fontStartIndex + i}
+          title={font.name}
+          description={
+            fontDescriptions[font.name] ? (
+              <p>{fontDescriptions[font.name]}</p>
+            ) : undefined
+          }
+        >
           <TypographySpecimen font={font} index={i} />
-        </Section>
+        </SectionSplit>
       ))}
 
       {/* N — Spacing & Layout */}
-      <SectionSplit index={spacingIndex} title={t("design.spacingGrid")}>
+      <SectionSplit
+        index={spacingIndex}
+        title={t("design.spacingGrid")}
+        description={<p>{t("design.spacingDesc")}</p>}
+      >
         <div className="space-y-0">
           {[
             {
@@ -411,7 +439,12 @@ export default function TypographyPageClient() {
       </SectionSplit>
 
       {/* N+1 — Motion & Interaction */}
-      <SectionSplit index={motionIndex} title={t("design.motionInteraction")}>
+      <SectionSplit
+        index={motionIndex}
+        title={t("design.motionInteraction")}
+        description={<p>{t("design.motionDesc")}</p>}
+      >
+        {" "}
         <div className="space-y-0">
           {[
             {
@@ -468,20 +501,18 @@ export default function TypographyPageClient() {
           </div>
         }
       >
-        <div className="relative border border-border bg-card overflow-hidden">
-          <div className="relative w-full aspect-[3/2] overflow-hidden">
-            <div className="absolute top-2 left-2 z-10 px-2 py-1 text-[10px] font-heading uppercase tracking-wider text-secondary bg-card/80 backdrop-blur-sm border border-border pointer-events-none">
-              {t("common.relatedGraph")}
-            </div>
-            <NavigationLink
-              href="/graph"
-              className="absolute top-2 right-2 z-10 px-2 py-1 text-[10px] font-heading uppercase tracking-wider text-secondary hover:text-primary bg-card/80 backdrop-blur-sm border border-border transition-colors"
-            >
-              {t("design.fullGraph")} →
-            </NavigationLink>
-            <EmbeddedGraph />
-          </div>
-        </div>
+        <GraphNextUp
+          defaultHubSlug="root"
+          defaultHubCard={{
+            slug: "root",
+            title: "Harry Chang",
+            category: "harrychang.me",
+            imageUrl: "/images/og-image.webp",
+            href: "/",
+            rawImage: true,
+          }}
+          className="w-full"
+        />
       </SectionSplit>
     </article>
   );

--- a/packages/ui/gallery-section.tsx
+++ b/packages/ui/gallery-section.tsx
@@ -169,6 +169,13 @@ export default function GallerySection({
     ? null
     : createBalancedLayout(displayedItems, getPinnedItemsMap(displayedItems));
 
+  // Pre-compute layout from initialItems for skeleton sizing (dims are locale-independent)
+  const skeletonItems = limit ? initialItems.slice(0, limit) : initialItems;
+  const skeletonLayout =
+    isLoading && skeletonItems.length > 0
+      ? createBalancedLayout(skeletonItems, getPinnedItemsMap(skeletonItems))
+      : null;
+
   // Helper function to create a placeholder with a specific aspect ratio
   const renderPlaceholderCard = (aspectRatio: string, index: number) => (
     <div key={index} className="mb-2 md:mb-4">
@@ -228,22 +235,59 @@ export default function GallerySection({
           style={{ transition: "min-height 0.3s ease-out" }}
         >
           {isLoading ? (
-            <div className="flex flex-col md:flex-row w-full gap-[var(--column-spacing)]">
-              <div className="flex-1 space-y-[var(--column-spacing)]">
-                {renderPlaceholderCard("100%", 1)}
-                {renderPlaceholderCard("100%", 2)}
+            skeletonLayout ? (
+              <>
+                {/* Mobile skeleton */}
+                <div className="flex flex-col w-full gap-[var(--column-spacing)] md:hidden">
+                  {skeletonItems.map((item, index) => {
+                    const w = item.width;
+                    const h = item.height;
+                    const raw = w && h ? w / h : 1;
+                    const clamped = raw < 0.8 ? 0.8 : raw > 1.25 ? 1.25 : raw;
+                    return renderPlaceholderCard(
+                      `${(1 / clamped) * 100}%`,
+                      index,
+                    );
+                  })}
+                </div>
+                {/* Desktop skeleton */}
+                <div className="hidden md:flex flex-row w-full gap-[var(--column-spacing)]">
+                  {skeletonLayout.columns.map((column, colIndex) => (
+                    <div
+                      key={colIndex}
+                      className="flex-1 space-y-[var(--column-spacing)]"
+                    >
+                      {column.map((layoutItem) => {
+                        const w = layoutItem.item.width;
+                        const h = layoutItem.item.height;
+                        const raw = w && h ? w / h : 1;
+                        const clamped =
+                          raw < 0.8 ? 0.8 : raw > 1.25 ? 1.25 : raw;
+                        return renderPlaceholderCard(
+                          `${(1 / clamped) * 100}%`,
+                          layoutItem.itemIndex,
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-col md:flex-row w-full gap-[var(--column-spacing)]">
+                <div className="flex-1 space-y-[var(--column-spacing)]">
+                  {renderPlaceholderCard("100%", 1)}
+                  {renderPlaceholderCard("100%", 2)}
+                </div>
+                <div className="flex-1 space-y-[var(--column-spacing)]">
+                  {renderPlaceholderCard("100%", 3)}
+                  {renderPlaceholderCard("100%", 4)}
+                </div>
+                <div className="flex-1 space-y-[var(--column-spacing)]">
+                  {renderPlaceholderCard("100%", 5)}
+                  {renderPlaceholderCard("100%", 6)}
+                </div>
               </div>
-
-              <div className="flex-1 space-y-[var(--column-spacing)]">
-                {renderPlaceholderCard("100%", 3)}
-                {renderPlaceholderCard("100%", 4)}
-              </div>
-
-              <div className="flex-1 space-y-[var(--column-spacing)]">
-                {renderPlaceholderCard("100%", 5)}
-                {renderPlaceholderCard("100%", 6)}
-              </div>
-            </div>
+            )
           ) : (
             <>
               {/* Mobile View: Linear Stack */}

--- a/packages/ui/image-container.tsx
+++ b/packages/ui/image-container.tsx
@@ -18,6 +18,8 @@ interface ImageContainerProps {
   sizes?: string; // Optional sizes attribute for responsive layouts
   imgClassName?: string; // Added: Pass classes to the inner Image component
   restrictPortraitWidth?: boolean; // Added: Toggle desktop portrait centering (default true)
+  /** Skip the custom webpLoader and responsive-variant thumbnail derivation (for images not in the optimization pipeline). */
+  rawImage?: boolean;
 }
 
 export function ImageContainer({
@@ -31,6 +33,7 @@ export function ImageContainer({
   sizes = "100vw",
   imgClassName,
   restrictPortraitWidth = true,
+  rawImage = false,
 }: ImageContainerProps) {
   const containerRef = useRef<HTMLElement>(null);
   const isVisible = useIntersectionObserver({
@@ -59,20 +62,19 @@ export function ImageContainer({
   let thumbnailSrc: string | undefined;
   let fullSrc = src;
 
-  if (isVideo) {
-    // Videos don't have generated thumbnails in this pipeline
-    // We rely on the skeleton until the video data loads
+  if (rawImage) {
+    thumbnailSrc = undefined;
+    fullSrc = src;
+  } else if (isVideo) {
     thumbnailSrc = undefined;
     fullSrc = src;
   } else if (src?.endsWith("-thumb.webp")) {
-    // Card / preview URLs already point at the thumbnail
     thumbnailSrc = src;
     fullSrc = src.replace("-thumb.webp", ".webp");
   } else if (src?.endsWith(".webp")) {
     thumbnailSrc = src.replace(".webp", "-thumb.webp");
     fullSrc = src;
   } else if (src) {
-    // Non-webp fallback – just use the same URL for both
     thumbnailSrc = src;
     fullSrc = src;
   }
@@ -202,7 +204,7 @@ export function ImageContainer({
                       } ${imgClassName || ""}`}
                       sizes={sizes}
                       quality={quality}
-                      {...(fullSrc?.endsWith(".webp")
+                      {...(!rawImage && fullSrc?.endsWith(".webp")
                         ? { loader: webpLoader }
                         : {})}
                       onLoad={() => {

--- a/packages/ui/next-up-card.tsx
+++ b/packages/ui/next-up-card.tsx
@@ -26,6 +26,8 @@ interface NextUpCardProps {
   tags?: string[];
   /** Render a plain div instead of NavigationLink (e.g. for non-navigable nodes). */
   disableLink?: boolean;
+  /** Skip the image optimization pipeline (for OG images / non-optimized assets). */
+  rawImage?: boolean;
 }
 
 export default function NextUpCard({
@@ -39,6 +41,7 @@ export default function NextUpCard({
   label,
   tags,
   disableLink = false,
+  rawImage = false,
 }: NextUpCardProps) {
   const { t } = useLanguage();
 
@@ -79,6 +82,7 @@ export default function NextUpCard({
               quality={50}
               noInsetPadding
               aspectRatio={1.5}
+              rawImage={rawImage}
             />
           </div>
         )}

--- a/packages/ui/next-up-card.tsx
+++ b/packages/ui/next-up-card.tsx
@@ -83,6 +83,7 @@ export default function NextUpCard({
               noInsetPadding
               aspectRatio={1.5}
               rawImage={rawImage}
+              sizes="(min-width: 768px) 144px, 96px"
             />
           </div>
         )}


### PR DESCRIPTION
## Summary
- **Hub node OG images**: Added `rawImage` prop to `ImageContainer` to bypass `webpLoader` and thumbnail derivation for non-optimized assets (OG images). Fixes 404s when hovering hub nodes (home, /design, /cv, etc.) on both the embedded graph `NextUpCard` and the full `/graph` page (`NodePreviewCard`, `MobileNodeCard`).
- **/design NextUpCard**: Extended `GraphNextUp` with `defaultHubSlug`, `defaultHubCard`, and `className` props. The /design page now renders the same graph+card combo as blog/gallery/project pages, centered on the home hub node with a synchronous default card to prevent CLS.
- **Gallery skeleton CLS**: When loading zh-TW gallery items, placeholder skeletons now use `initialItems` dimensions (locale-independent) instead of hardcoded 1:1 squares, matching the final layout to prevent layout shift.

### Files changed
- `graph-utils.ts` — extracted shared `HUB_OG_IMAGES` map and `resolveHubImageUrl()`
- `embedded-graph.tsx` — added `focalHubSlug` prop for hub node centering
- `graph-next-up.tsx` — added `defaultHubSlug`, `defaultHubCard`, `className`, `rawImage` support
- `node-preview-card.tsx` / `mobile-node-card.tsx` — use `resolveHubImageUrl()` + `rawImage`
- `image-container.tsx` — added `rawImage` prop to skip webpLoader pipeline
- `next-up-card.tsx` — thread `rawImage` through to `ImageContainer`
- `typography-page-client.tsx` — replaced bare `EmbeddedGraph` with `GraphNextUp`
- `gallery-section.tsx` — dimension-aware skeleton placeholders from `initialItems`

## Test plan
- [ ] Visit `/design`, scroll to Knowledge Graph section — verify graph centers on home hub, NextUpCard shows "Harry Chang" with OG image
- [ ] Hover different nodes in /design graph — card should swap; unhover should revert to default
- [ ] Visit `/graph`, hover hub nodes (home, /cv, /design, /blog) — verify OG images appear in preview tooltip
- [ ] Visit `/graph` on mobile, scroll crosshair over hub nodes — verify bottom card shows OG images
- [ ] Visit `/blog/[any-slug]` — verify existing GraphNextUp still works correctly
- [ ] Switch language to zh-TW on gallery page — verify skeleton placeholders match final aspect ratios (no layout shift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hub node selection/centering added across graph components.
  * Hub-focused defaults for non-content pages and a consistent next-up card container.

* **Improvements**
  * Improved hub image resolution used in previews and cards.
  * Option to render raw images that bypass image optimization.
  * Gallery loading skeletons now match actual content layout.
  * Typography page now uses the new graph and refined section layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harrychangtw/portfolio-monorepo/pull/72)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->