### PR TITLE
feat(ci): zh-TW locale coverage + merged lighthouse table

### DIFF
--- a/.github/scripts/update-lighthouse-readme.js
+++ b/.github/scripts/update-lighthouse-readme.js
@@ -16,14 +16,22 @@ function readLhrDir(dir) {
   for (const file of lhrFiles) {
     try {
       const lhr = JSON.parse(fs.readFileSync(path.join(absDir, file), "utf8"));
-      const urlPath = new URL(lhr.requestedUrl).pathname || "/";
+      const url = new URL(lhr.requestedUrl);
+      const urlPath = url.pathname || "/";
+      const locale =
+        url.searchParams.get("lang")?.toLowerCase() === "zh-tw"
+          ? "ZH-TW"
+          : "EN";
+      const key = `${urlPath}|${locale}`;
       const perfScore = Math.round(
         (lhr.categories?.performance?.score ?? 0) * 100,
       );
-      const get = (key) => lhr.audits?.[key]?.displayValue ?? "-";
+      const get = (k) => lhr.audits?.[k]?.displayValue ?? "-";
 
-      if (!data[urlPath] || perfScore > data[urlPath].perfScore) {
-        data[urlPath] = {
+      if (!data[key] || perfScore > data[key].perfScore) {
+        data[key] = {
+          route: urlPath,
+          locale,
           perfScore,
           fcp: get("first-contentful-paint"),
           lcp: get("largest-contentful-paint"),
@@ -39,33 +47,57 @@ function readLhrDir(dir) {
   return data;
 }
 
-function buildRows(routeData) {
-  return Object.keys(routeData)
-    .sort()
-    .map((route) => {
-      const d = routeData[route];
-      const color =
-        d.perfScore >= 90
-          ? "success"
-          : d.perfScore >= 50
-            ? "important"
-            : "critical";
-      const badge = `![Lighthouse ${d.perfScore}](https://img.shields.io/badge/lighthouse-${d.perfScore}-${color}?style=flat-square)`;
-      return `| \`${route}\` | ${badge} | ${d.fcp} | ${d.lcp} | ${d.tbt} | ${d.cls} | ${d.si} |`;
-    })
-    .join("\n");
+function badge(score) {
+  const color =
+    score >= 90 ? "success" : score >= 50 ? "important" : "critical";
+  return `![${score}](https://img.shields.io/badge/${score}-${color}?style=flat-square)`;
 }
 
-const TABLE_HEADER = [
-  "| Tested Route | Performance | FCP | LCP | TBT | CLS | Speed Index |",
-  "|:---|:---|:---|:---|:---|:---|:---|",
-].join("\n");
+function metricsCell(d) {
+  if (!d) return "- | - | - | - | - | -";
+  return `${badge(d.perfScore)} | ${d.fcp} | ${d.lcp} | ${d.tbt} | ${d.cls} | ${d.si}`;
+}
+
+function buildMergedTable(desktopData, mobileData) {
+  const allKeys = new Set([
+    ...Object.keys(desktopData),
+    ...Object.keys(mobileData),
+  ]);
+
+  const rows = [];
+  for (const key of allKeys) {
+    const entry = desktopData[key] || mobileData[key];
+    rows.push({
+      route: entry.route,
+      locale: entry.locale,
+      desktop: desktopData[key] || null,
+      mobile: mobileData[key] || null,
+    });
+  }
+
+  rows.sort((a, b) => {
+    const r = a.route.localeCompare(b.route);
+    if (r !== 0) return r;
+    return a.locale.localeCompare(b.locale);
+  });
+
+  const header = [
+    "| Route | Locale | Desktop Perf | Desktop FCP | Desktop LCP | Desktop TBT | Desktop CLS | Desktop SI | Mobile Perf | Mobile FCP | Mobile LCP | Mobile TBT | Mobile CLS | Mobile SI |",
+    "|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|",
+  ].join("\n");
+
+  const body = rows
+    .map(
+      (r) =>
+        `| \`${r.route}\` | ${r.locale} | ${metricsCell(r.desktop)} | ${metricsCell(r.mobile)} |`,
+    )
+    .join("\n");
+
+  return `${header}\n${body}`;
+}
 
 const mode = process.argv.includes("--mode=prod") ? "prod" : "simulated";
 
-// `--readme=<relative-path>` lets a workflow target a different app's README
-// (e.g. apps/emilychang-me/README.md). Defaults to harrychang-me to preserve
-// existing behavior.
 const readmeArg = process.argv.find((a) => a.startsWith("--readme="));
 const readmeRel = readmeArg
   ? readmeArg.slice("--readme=".length)
@@ -91,23 +123,11 @@ if (mode === "prod") {
     ? `> 🕐 **Last audited:** ${timestamp}  \n> 🌐 **Deployment:** ${deploymentUrl}`
     : `> 🕐 **Last audited:** ${timestamp}`;
 
-  const sections = [];
-  if (hasDesktop) {
-    sections.push(
-      `#### Desktop (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(desktopData)}`,
-    );
-  }
-  if (hasMobile) {
-    sections.push(
-      `#### Mobile (Production Deployment)\n\n${TABLE_HEADER}\n${buildRows(mobileData)}`,
-    );
-  }
-
   const block = [
     "<!-- LIGHTHOUSE_PROD_RESULTS_START -->",
     header,
     "",
-    sections.join("\n\n"),
+    buildMergedTable(desktopData, mobileData),
     "<!-- LIGHTHOUSE_PROD_RESULTS_END -->",
   ].join("\n");
 
@@ -142,19 +162,11 @@ if (!hasDesktop && !hasMobile) {
   process.exit(0);
 }
 
-const sections = [];
-if (hasDesktop) {
-  sections.push(`#### Desktop\n\n${TABLE_HEADER}\n${buildRows(desktopData)}`);
-}
-if (hasMobile) {
-  sections.push(`#### Mobile\n\n${TABLE_HEADER}\n${buildRows(mobileData)}`);
-}
-
 const block = [
   "<!-- LIGHTHOUSE_RESULTS_START -->",
   `> 🕐 **Last audited:** ${timestamp}`,
   "",
-  sections.join("\n\n"),
+  buildMergedTable(desktopData, mobileData),
   "<!-- LIGHTHOUSE_RESULTS_END -->",
 ].join("\n");
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -93,6 +93,32 @@ jobs:
             http://localhost:3000/blog/2026_01_10_plushies
             http://localhost:3000/blog/2026_02_10_synecdoche_truman
             http://localhost:3000/graph
+            http://localhost:3000/?lang=zh-tw
+            http://localhost:3000/blog?lang=zh-tw
+            http://localhost:3000/projects?lang=zh-tw
+            http://localhost:3000/gallery?lang=zh-tw
+            http://localhost:3000/uses?lang=zh-tw
+            http://localhost:3000/cv?lang=zh-tw
+            http://localhost:3000/linktree?lang=zh-tw
+            http://localhost:3000/design?lang=zh-tw
+            http://localhost:3000/paper-reading?lang=zh-tw
+            http://localhost:3000/manifesto?lang=zh-tw
+            http://localhost:3000/projects/2025_04_12_portfolio?lang=zh-tw
+            http://localhost:3000/projects/2024_09_23_chingshin_rag?lang=zh-tw
+            http://localhost:3000/projects/2025_03_08_sitcon_keynote?lang=zh-tw
+            http://localhost:3000/projects/2025_08_04_debate?lang=zh-tw
+            http://localhost:3000/projects/2024_08_19_classics_reimagined?lang=zh-tw
+            http://localhost:3000/gallery/2026_02_08_italy_mountain?lang=zh-tw
+            http://localhost:3000/gallery/2023_07_07_splash_of_red?lang=zh-tw
+            http://localhost:3000/gallery/2023_10_06_against_giants?lang=zh-tw
+            http://localhost:3000/gallery/2023_11_18_dusk_impressions?lang=zh-tw
+            http://localhost:3000/gallery/2024_01_06_hehuanshan?lang=zh-tw
+            http://localhost:3000/blog/9_m11d?lang=zh-tw
+            http://localhost:3000/blog/2025_12_19_xpro1?lang=zh-tw
+            http://localhost:3000/blog/2025_12_22_aftersun_paris_texas?lang=zh-tw
+            http://localhost:3000/blog/2026_01_10_plushies?lang=zh-tw
+            http://localhost:3000/blog/2026_02_10_synecdoche_truman?lang=zh-tw
+            http://localhost:3000/graph?lang=zh-tw
           configPath: apps/harrychang-me/.lighthouserc.mobile.json
           artifactName: lighthouse-results-mobile
           uploadArtifacts: true
@@ -140,6 +166,32 @@ jobs:
             http://localhost:3000/blog/2026_01_10_plushies
             http://localhost:3000/blog/2026_02_10_synecdoche_truman
             http://localhost:3000/graph
+            http://localhost:3000/?lang=zh-tw
+            http://localhost:3000/blog?lang=zh-tw
+            http://localhost:3000/projects?lang=zh-tw
+            http://localhost:3000/gallery?lang=zh-tw
+            http://localhost:3000/uses?lang=zh-tw
+            http://localhost:3000/cv?lang=zh-tw
+            http://localhost:3000/linktree?lang=zh-tw
+            http://localhost:3000/design?lang=zh-tw
+            http://localhost:3000/paper-reading?lang=zh-tw
+            http://localhost:3000/manifesto?lang=zh-tw
+            http://localhost:3000/projects/2025_04_12_portfolio?lang=zh-tw
+            http://localhost:3000/projects/2024_09_23_chingshin_rag?lang=zh-tw
+            http://localhost:3000/projects/2025_03_08_sitcon_keynote?lang=zh-tw
+            http://localhost:3000/projects/2025_08_04_debate?lang=zh-tw
+            http://localhost:3000/projects/2024_08_19_classics_reimagined?lang=zh-tw
+            http://localhost:3000/gallery/2026_02_08_italy_mountain?lang=zh-tw
+            http://localhost:3000/gallery/2023_07_07_splash_of_red?lang=zh-tw
+            http://localhost:3000/gallery/2023_10_06_against_giants?lang=zh-tw
+            http://localhost:3000/gallery/2023_11_18_dusk_impressions?lang=zh-tw
+            http://localhost:3000/gallery/2024_01_06_hehuanshan?lang=zh-tw
+            http://localhost:3000/blog/9_m11d?lang=zh-tw
+            http://localhost:3000/blog/2025_12_19_xpro1?lang=zh-tw
+            http://localhost:3000/blog/2025_12_22_aftersun_paris_texas?lang=zh-tw
+            http://localhost:3000/blog/2026_01_10_plushies?lang=zh-tw
+            http://localhost:3000/blog/2026_02_10_synecdoche_truman?lang=zh-tw
+            http://localhost:3000/graph?lang=zh-tw
           configPath: apps/harrychang-me/.lighthouserc.json
           artifactName: lighthouse-results-desktop
           uploadArtifacts: true


### PR DESCRIPTION
## Summary

- **zh-TW locale audits**: Every route in `lighthouse.yml` is now audited twice — once default (EN), once with `?lang=zh-tw`. The `LanguageContext` reads this query param client-side and switches locale before hydration completes, so post-hydration metrics (LCP, CLS) reflect zh-TW rendering.
- **Merged table format**: Desktop and Mobile sub-tables are merged into one wide horizontal table per marker block. Rows are keyed by Route + Locale (EN / ZH-TW). Column groups: Desktop (Perf, FCP, LCP, TBT, CLS, SI) and Mobile (same). Shield badges on perf score columns only.
- Preserves both `LIGHTHOUSE_RESULTS_START/END` and `LIGHTHOUSE_PROD_RESULTS_START/END` markers.

## Notes

- The script change also applies to `lighthouse-prod.yml` and `lighthouse-prod-emily.yml` since they share `update-lighthouse-readme.js`. Prod workflows will render in the new merged format on next run (with EN-only rows until zh-TW URLs are added there too).
- `?lang=zh-tw` is purely client-side — SSR renders English, then the `LanguageProvider` reads the query param and re-renders in zh-TW. The FCP measures the visibility gate (blank div) either way; the meaningful difference shows up in LCP and layout metrics.

## Test plan

- [ ] Trigger `lighthouse.yml` via `workflow_dispatch` and verify 52 URLs per device run (26 EN + 26 ZH-TW)
- [ ] Verify README gets a single merged table with Route, Locale, Desktop, and Mobile column groups
- [ ] Verify `lighthouse-prod.yml` still works (EN-only rows, no ZH-TW since prod URLs unchanged)
- [ ] Spot-check a zh-TW LHR artifact to confirm the page actually rendered in Chinese

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Lighthouse performance monitoring to include localized page testing for Traditional Chinese
  * Consolidated performance reports with Desktop and Mobile metrics displayed together in unified tables

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Harrychangtw/portfolio-monorepo/pull/74)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->