### PR TITLE
feat: add interactive compare slider for image pairs

### DIFF
--- a/packages/lib/image-pipeline/engine.js
+++ b/packages/lib/image-pipeline/engine.js
@@ -9,7 +9,8 @@ function walkImages(dir) {
   const out = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...walkImages(full));
+    if (entry.isDirectory() && entry.name !== "raw")
+      out.push(...walkImages(full));
     else if (/\.(jpg|jpeg|png)$/i.test(entry.name)) out.push(full);
   }
   return out;

--- a/packages/lib/image-pipeline/planners.js
+++ b/packages/lib/image-pipeline/planners.js
@@ -165,6 +165,7 @@ async function buildPlansForCategory(name, spec, directories) {
 
   if (mode === "gallery") {
     const folders = fs.readdirSync(source).filter((f) => {
+      if (f === "raw") return false;
       try {
         return fs.statSync(path.join(source, f)).isDirectory();
       } catch {

--- a/packages/lib/lib/markdown.ts
+++ b/packages/lib/lib/markdown.ts
@@ -1137,6 +1137,56 @@ function transformMedia() {
         alt = alt.replace(/\s*:framed$/i, "");
       }
 
+      // Check for compare: prefix (before or after framed: stripping)
+      let isCompare = false;
+      if (alt.toLowerCase().startsWith("compare:")) {
+        isCompare = true;
+        alt = alt.replace(/^compare:\s*/i, "");
+      }
+
+      // Handle compare slider: ![compare:Caption](left.webp|right.webp)
+      if (isCompare && url.includes("|")) {
+        const [leftRaw, rightRaw] = url.split("|").map((s) => s.trim());
+        const leftUrl = getFullResolutionPath(leftRaw);
+        const rightUrl = getFullResolutionPath(rightRaw);
+        const dims = getDimsFromWebPath(leftUrl);
+        const aspectRatio =
+          dims && dims.width && dims.height
+            ? (dims.width / dims.height).toFixed(4)
+            : "";
+
+        const escapeAttr = (value: string) =>
+          value
+            .replace(/&/g, "&amp;")
+            .replace(/"/g, "&quot;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+
+        const anchorId = `img-${imgIdx++}`;
+        const compareNode: HTML = {
+          type: "html",
+          value: `
+            <figure id="${anchorId}" class="my-6 w-full graph-anchor-target">
+              <div
+                class="markdown-compare-placeholder"
+                data-left-src="${escapeAttr(leftUrl)}"
+                data-right-src="${escapeAttr(rightUrl)}"
+                data-aspect-ratio="${aspectRatio}"
+                data-framed="${isFramed}"
+                data-alt="${escapeAttr(alt)}"
+              ></div>
+              ${
+                alt
+                  ? `<figcaption class="mt-2 text-sm text-left" style="color: hsl(var(--secondary)); font-family: var(--font-body);">${alt}</figcaption>`
+                  : ""
+              }
+            </figure>
+          `,
+        };
+        parent.children.splice(index, 1, compareNode);
+        return;
+      }
+
       // Check if it's a Google Drive video link
       const driveRegex =
         /https?:\/\/drive\.google\.com\/file\/d\/([a-zA-Z0-9_-]+)/;

--- a/packages/ui/blog-post-client.tsx
+++ b/packages/ui/blog-post-client.tsx
@@ -13,6 +13,7 @@ const ThemeSwitcher = dynamic(() => import("@portfolio/ui/theme-switcher"), {
   ssr: false,
 });
 import { ImageContainer } from "@portfolio/ui/image-container";
+import { CompareSlider } from "@portfolio/ui/compare-slider";
 import type { PostMetadata } from "@portfolio/lib/lib/markdown";
 import NextUpCard from "@portfolio/ui/next-up-card";
 import NavigationLink from "@portfolio/ui/navigation-link";
@@ -247,6 +248,31 @@ export default function BlogPostClient({
               <div className="prose prose-lg max-w-none dark:prose-invert mb-16 md:mb-24">
                 {parse(post.contentHtml, {
                   replace: (domNode) => {
+                    if (
+                      domNode instanceof Element &&
+                      domNode.attribs &&
+                      domNode.attribs.class === "markdown-compare-placeholder"
+                    ) {
+                      const {
+                        "data-left-src": leftSrc,
+                        "data-right-src": rightSrc,
+                        "data-alt": alt,
+                        "data-aspect-ratio": aspectRatio,
+                        "data-framed": framed,
+                      } = domNode.attribs;
+                      return (
+                        <CompareSlider
+                          leftSrc={leftSrc}
+                          rightSrc={rightSrc}
+                          alt={alt || ""}
+                          aspectRatio={
+                            aspectRatio ? parseFloat(aspectRatio) : undefined
+                          }
+                          noInsetPadding={framed !== "true"}
+                          quality={95}
+                        />
+                      );
+                    }
                     if (
                       domNode instanceof Element &&
                       domNode.attribs &&

--- a/packages/ui/compare-slider.tsx
+++ b/packages/ui/compare-slider.tsx
@@ -98,7 +98,12 @@ export function CompareSlider({
           >
             {!noInsetPadding && (
               <div
-                className={`absolute inset-0 z-20 pointer-events-none border-l-[${borderThickness}] border-r-[${borderThickness}] border-white`}
+                className="absolute inset-0 z-20 pointer-events-none border-white"
+                style={{
+                  borderLeftWidth: borderThickness,
+                  borderRightWidth: borderThickness,
+                  boxSizing: "border-box",
+                }}
               />
             )}
 

--- a/packages/ui/compare-slider.tsx
+++ b/packages/ui/compare-slider.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import Image from "next/image";
+import { useIsMobile } from "@portfolio/lib/hooks/use-mobile";
+import { ImageLoadingSkeleton } from "./image-loading-skeleton";
+import { useIntersectionObserver } from "@portfolio/lib/hooks/use-intersection-observer";
+
+interface CompareSliderProps {
+  leftSrc: string;
+  rightSrc: string;
+  alt: string;
+  aspectRatio?: number;
+  noInsetPadding?: boolean;
+  quality?: number;
+}
+
+export function CompareSlider({
+  leftSrc,
+  rightSrc,
+  alt,
+  aspectRatio: providedAspectRatio,
+  noInsetPadding = false,
+  quality = 80,
+}: CompareSliderProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isVisible = useIntersectionObserver({
+    elementRef: containerRef as React.RefObject<Element>,
+    rootMargin: "50px",
+  });
+
+  const aspectRatio = providedAspectRatio ?? 1.5;
+  const isMobile = useIsMobile();
+
+  const [position, setPosition] = useState(50);
+  const [isDragging, setIsDragging] = useState(false);
+  const [leftLoaded, setLeftLoaded] = useState(false);
+  const [rightLoaded, setRightLoaded] = useState(false);
+  const bothLoaded = leftLoaded && rightLoaded;
+
+  const leftThumb = leftSrc.endsWith(".webp")
+    ? leftSrc.replace(".webp", "-thumb.webp")
+    : undefined;
+  const rightThumb = rightSrc.endsWith(".webp")
+    ? rightSrc.replace(".webp", "-thumb.webp")
+    : undefined;
+
+  const updatePosition = useCallback((clientX: number) => {
+    if (!containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const x = clientX - rect.left;
+    const pct = Math.max(0, Math.min(100, (x / rect.width) * 100));
+    setPosition(pct);
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      setIsDragging(true);
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      updatePosition(e.clientX);
+    },
+    [updatePosition],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDragging) return;
+      updatePosition(e.clientX);
+    },
+    [isDragging, updatePosition],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const insetPadding = noInsetPadding ? 0 : isMobile ? 4 : 7;
+  const minThickness = 1;
+  const maxThickness = isMobile ? 4 : 6;
+  const borderThickness = `clamp(${minThickness}px, 0.01 * 100%, ${maxThickness}px)`;
+
+  return (
+    <figure className="w-full not-prose" ref={containerRef}>
+      <div className="w-full">
+        <div
+          className={`relative w-full ${noInsetPadding ? "" : "bg-white"}`}
+          style={{
+            padding: `${insetPadding}px`,
+          }}
+        >
+          <div
+            className="relative w-full overflow-hidden select-none"
+            style={{ paddingBottom: `${(1 / aspectRatio) * 100}%` }}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerCancel={handlePointerUp}
+          >
+            {!noInsetPadding && (
+              <div
+                className={`absolute inset-0 z-20 pointer-events-none border-l-[${borderThickness}] border-r-[${borderThickness}] border-white`}
+              />
+            )}
+
+            <ImageLoadingSkeleton visible={!bothLoaded} />
+
+            {/* Blurred thumbnails */}
+            {leftThumb && isVisible && (
+              <div
+                className={`absolute inset-0 z-[5] pointer-events-none transition-opacity duration-500 ${bothLoaded ? "opacity-0" : "opacity-100"}`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={leftThumb}
+                  alt=""
+                  className="w-full h-full object-cover object-center"
+                  style={
+                    noInsetPadding
+                      ? { filter: "blur(20px)", transform: "scale(1.5)" }
+                      : undefined
+                  }
+                />
+              </div>
+            )}
+
+            {/* Right image (full, behind) */}
+            <div className="absolute inset-0 z-0">
+              {isVisible && (
+                <Image
+                  src={rightSrc}
+                  alt={alt ? `${alt} (right)` : ""}
+                  fill
+                  className={`object-cover object-center transition-opacity duration-500 ${bothLoaded ? "opacity-100" : "opacity-0"}`}
+                  sizes="100vw"
+                  quality={quality}
+                  onLoad={() => setRightLoaded(true)}
+                />
+              )}
+            </div>
+
+            {/* Left image (clipped) */}
+            <div
+              className="absolute inset-0 z-10"
+              style={{ clipPath: `inset(0 ${100 - position}% 0 0)` }}
+            >
+              {isVisible && (
+                <Image
+                  src={leftSrc}
+                  alt={alt ? `${alt} (left)` : ""}
+                  fill
+                  className={`object-cover object-center transition-opacity duration-500 ${bothLoaded ? "opacity-100" : "opacity-0"}`}
+                  sizes="100vw"
+                  quality={quality}
+                  onLoad={() => setLeftLoaded(true)}
+                />
+              )}
+            </div>
+
+            {/* Slider line + handle */}
+            {bothLoaded && (
+              <div
+                className="absolute top-0 bottom-0 z-30 pointer-events-none"
+                style={{ left: `${position}%`, transform: "translateX(-50%)" }}
+              >
+                <div
+                  className="w-px h-full bg-white/80 mx-auto"
+                  style={{ boxShadow: "0 0 4px rgba(0,0,0,0.4)" }}
+                />
+                <div
+                  className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white/90 border border-white/50 flex items-center justify-center pointer-events-auto cursor-ew-resize"
+                  style={{ boxShadow: "0 1px 4px rgba(0,0,0,0.3)" }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <path
+                      d="M4.5 3L1.5 7L4.5 11"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M9.5 3L12.5 7L9.5 11"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </figure>
+  );
+}

--- a/packages/ui/gallery-post-client.tsx
+++ b/packages/ui/gallery-post-client.tsx
@@ -13,6 +13,7 @@ const ThemeSwitcher = dynamic(() => import("@portfolio/ui/theme-switcher"), {
   ssr: false,
 });
 import { ImageContainer } from "@portfolio/ui/image-container";
+import { CompareSlider } from "@portfolio/ui/compare-slider";
 import NextUpCard from "@portfolio/ui/next-up-card";
 import type { GalleryItemMetadata } from "@portfolio/lib/lib/markdown";
 import NavigationLink from "@portfolio/ui/navigation-link";
@@ -271,6 +272,31 @@ export default function GalleryPostClient({
                 <div className="prose prose-lg max-w-none dark:prose-invert mb-16 md:mb-24">
                   {parse(item.contentHtml, {
                     replace: (domNode) => {
+                      if (
+                        domNode instanceof Element &&
+                        domNode.attribs &&
+                        domNode.attribs.class === "markdown-compare-placeholder"
+                      ) {
+                        const {
+                          "data-left-src": leftSrc,
+                          "data-right-src": rightSrc,
+                          "data-alt": alt,
+                          "data-aspect-ratio": aspectRatio,
+                          "data-framed": framed,
+                        } = domNode.attribs;
+                        return (
+                          <CompareSlider
+                            leftSrc={leftSrc}
+                            rightSrc={rightSrc}
+                            alt={alt || ""}
+                            aspectRatio={
+                              aspectRatio ? parseFloat(aspectRatio) : undefined
+                            }
+                            noInsetPadding={framed !== "true"}
+                            quality={95}
+                          />
+                        );
+                      }
                       if (
                         domNode instanceof Element &&
                         domNode.attribs &&

--- a/packages/ui/project-post-client.tsx
+++ b/packages/ui/project-post-client.tsx
@@ -14,6 +14,7 @@ const ThemeSwitcher = dynamic(() => import("@portfolio/ui/theme-switcher"), {
   ssr: false,
 });
 import { ImageContainer } from "@portfolio/ui/image-container";
+import { CompareSlider } from "@portfolio/ui/compare-slider";
 import type { ProjectMetadata } from "@portfolio/lib/lib/markdown";
 import NextUpCard from "@portfolio/ui/next-up-card";
 import NavigationLink from "@portfolio/ui/navigation-link";
@@ -279,6 +280,31 @@ export default function ProjectPostClient({
                 <div className="prose prose-lg max-w-none dark:prose-invert mb-16 md:mb-24">
                   {parse(project.contentHtml, {
                     replace: (domNode) => {
+                      if (
+                        domNode instanceof Element &&
+                        domNode.attribs &&
+                        domNode.attribs.class === "markdown-compare-placeholder"
+                      ) {
+                        const {
+                          "data-left-src": leftSrc,
+                          "data-right-src": rightSrc,
+                          "data-alt": alt,
+                          "data-aspect-ratio": aspectRatio,
+                          "data-framed": framed,
+                        } = domNode.attribs;
+                        return (
+                          <CompareSlider
+                            leftSrc={leftSrc}
+                            rightSrc={rightSrc}
+                            alt={alt || ""}
+                            aspectRatio={
+                              aspectRatio ? parseFloat(aspectRatio) : undefined
+                            }
+                            noInsetPadding={framed !== "true"}
+                            quality={95}
+                          />
+                        );
+                      }
                       if (
                         domNode instanceof Element &&
                         domNode.attribs &&


### PR DESCRIPTION
## Summary
- Adds a `compare:` prefix for markdown images that renders an interactive left-right slider for comparing two images side by side
- Syntax: `![compare:Caption](left.webp|right.webp)`, combinable with `framed:` as `![framed:compare:Caption](...)`
- Single caption below the slider, no overlay labels — keeps it generic for any comparison (before/after, empty/full, etc.)

## Changes
- **`packages/lib/lib/markdown.ts`** — `transformMedia()` detects `compare:` prefix, splits URL on `|`, emits `markdown-compare-placeholder` div
- **`packages/ui/compare-slider.tsx`** — new interactive slider component with pointer events, blur-up loading, clipPath-based reveal
- **`packages/ui/{blog,project,gallery}-post-client.tsx`** — hydrate compare placeholders into `<CompareSlider>`
- **`packages/lib/image-pipeline/`** — minor pipeline changes bundled

## Test plan
- [ ] Add `![compare:Caption](left.webp|right.webp)` to a project/blog/gallery markdown file
- [ ] Verify slider renders at 50% default position with draggable handle
- [ ] Verify touch + mouse drag works
- [ ] Verify `framed:compare:` combination applies white border treatment
- [ ] Verify blur-up loading works for both images
- [ ] Verify existing `framed:` and regular images still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Introduced interactive before/after image comparison slider for detailed visual analysis
- Draggable slider control to progressively reveal and compare before/after versions
- Available in blog posts, galleries, and project pages
- Intelligent lazy-loading optimizes performance
- Supports custom aspect ratios and responsive image sizing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->