### PR TITLE
feat: add privacy page with bilingual support

### DIFF
--- a/apps/harrychang-me/app/(main)/privacy/page.tsx
+++ b/apps/harrychang-me/app/(main)/privacy/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import PrivacyContent from "@/components/main/privacy-content";
+
+export const metadata: Metadata = {
+  title: "Privacy",
+  description:
+    "How harrychang.me handles your data — cookies, analytics, and third-party services.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+export default function PrivacyPage() {
+  return <PrivacyContent />;
+}

--- a/apps/harrychang-me/app/sitemap.ts
+++ b/apps/harrychang-me/app/sitemap.ts
@@ -50,6 +50,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/uses",
     "/design",
     "/linktree",
+    "/privacy",
   ];
 
   staticPages.forEach((page) => {

--- a/apps/harrychang-me/components/footer.tsx
+++ b/apps/harrychang-me/components/footer.tsx
@@ -54,7 +54,8 @@ const siteLinks = [
   { id: "projects", name: "Projects", href: "/#projects" },
   { id: "gallery", name: "Gallery", href: "/#gallery" },
   { id: "blog", name: "Blog", href: "/blog" },
-  { id: "linktree", name: "Links", href: "/linktree" },
+  { id: "privacy", name: "Privacy", href: "/privacy" },
+  // { id: "linktree", name: "Links", href: "/linktree" },
   { id: "manifesto", name: "Manifesto", href: "/manifesto" },
   { id: "source", name: "Source Code", href: "/readme" },
 ];

--- a/apps/harrychang-me/components/header.tsx
+++ b/apps/harrychang-me/components/header.tsx
@@ -36,6 +36,7 @@ const SPECIAL_PAGES = [
   { prefix: "/linktree", key: "links" },
   { prefix: "/design", key: "design" },
   { prefix: "/cv", key: "cv" },
+  { prefix: "/privacy", key: "privacy" },
 ];
 
 export default function Header() {

--- a/apps/harrychang-me/components/main/privacy-content.tsx
+++ b/apps/harrychang-me/components/main/privacy-content.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useLanguage } from "@portfolio/lib/contexts/language-context";
+
+function Section({
+  index,
+  title,
+  children,
+}: {
+  index: number;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-12 gap-4 md:gap-6 py-8 md:py-10 border-t border-border">
+      <div className="col-span-1 hidden md:block">
+        <span className="label-mono">{String(index).padStart(2, "0")}</span>
+      </div>
+
+      <div className="col-span-12 md:col-span-4 mb-4 md:mb-0">
+        <h2 className="section-label">{title}</h2>
+      </div>
+
+      <div className="col-span-12 md:col-start-7 md:col-span-6">{children}</div>
+    </div>
+  );
+}
+
+export default function PrivacyContent() {
+  const { t, tHtml } = useLanguage();
+
+  return (
+    <article className="container mt-24 md:mt-32 mb-24 md:mb-32">
+      <div className="mb-6 md:mb-8">
+        <h1 className="font-heading text-[clamp(2.25rem,5.5vw,4.5rem)] font-regular tracking-[-0.02em] text-foreground leading-[0.95]">
+          {t("privacy.title")}
+        </h1>
+      </div>
+
+      <Section index={1} title={t("privacy.overview.title")}>
+        <p className="font-body text text-primary leading-relaxed">
+          {tHtml("privacy.overview.body")}
+        </p>
+      </Section>
+
+      <Section index={2} title={t("privacy.cookies.title")}>
+        <p className="font-body text text-primary leading-relaxed">
+          {tHtml("privacy.cookies.body")}
+        </p>
+      </Section>
+
+      <Section index={3} title={t("privacy.analytics.title")}>
+        <p className="font-body text text-primary leading-relaxed">
+          {tHtml("privacy.analytics.body")}
+        </p>
+      </Section>
+
+      <Section index={4} title={t("privacy.guestbook.title")}>
+        <p className="font-body text text-primary leading-relaxed">
+          {tHtml("privacy.guestbook.body")}
+        </p>
+      </Section>
+
+      <Section index={5} title={t("privacy.thirdParty.title")}>
+        <p className="font-body text text-primary leading-relaxed">
+          {tHtml("privacy.thirdParty.body")}
+        </p>
+      </Section>
+
+      <Section index={6} title={t("privacy.rights.title")}>
+        <p className="font-body text text-primary leading-relaxed">
+          {tHtml("privacy.rights.body")}
+        </p>
+      </Section>
+    </article>
+  );
+}

--- a/apps/harrychang-me/components/main/updates-section.tsx
+++ b/apps/harrychang-me/components/main/updates-section.tsx
@@ -4,32 +4,41 @@ import { motion, AnimatePresence } from "motion/react";
 import { useLanguage } from "@portfolio/lib/contexts/language-context";
 
 const parseHtmlToReact = (htmlString: string): React.ReactNode => {
-  const linkRegex = /<a\s+href="([^"]*)"[^>]*>([^<]*)<\/a>/g;
+  const tagRegex =
+    /<a\s+href="([^"]*)"[^>]*>([^<]*)<\/a>|<strong>([^<]*)<\/strong>/g;
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
   let match;
   let key = 0;
 
-  while ((match = linkRegex.exec(htmlString)) !== null) {
+  while ((match = tagRegex.exec(htmlString)) !== null) {
     if (match.index > lastIndex) {
       const textBefore = htmlString.substring(lastIndex, match.index);
       if (textBefore)
         parts.push(<span key={`text-${key++}`}>{textBefore}</span>);
     }
-    const href = match[1];
-    const linkText = match[2];
-    parts.push(
-      <a
-        key={`link-${key++}`}
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="link-external"
-      >
-        {linkText}
-      </a>,
-    );
-    lastIndex = linkRegex.lastIndex;
+    if (match[3] !== undefined) {
+      parts.push(
+        <strong key={`strong-${key++}`} className="font-medium">
+          {match[3]}
+        </strong>,
+      );
+    } else {
+      const href = match[1];
+      const linkText = match[2];
+      parts.push(
+        <a
+          key={`link-${key++}`}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="link-external"
+        >
+          {linkText}
+        </a>,
+      );
+    }
+    lastIndex = tagRegex.lastIndex;
   }
   if (lastIndex < htmlString.length) {
     const remainingText = htmlString.substring(lastIndex);

--- a/apps/harrychang-me/content/generated/image-dims.json
+++ b/apps/harrychang-me/content/generated/image-dims.json
@@ -1,1 +1,1267 @@
-{"/images/optimized/blogs/10-lego-mount/l1001284.webp":{"width":1804,"height":1200},"/images/optimized/blogs/10-lego-mount/l1001285.webp":{"width":1805,"height":1200},"/images/optimized/blogs/10-lego-mount/l1001286.webp":{"width":1805,"height":1200},"/images/optimized/blogs/10-lego-mount/l1001288.webp":{"width":1805,"height":1200},"/images/optimized/blogs/10-lego-mount/l1001290.webp":{"width":1805,"height":1200},"/images/optimized/blogs/10-lego-mount/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/11-portfolio/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/12-us-trip/l1001460.webp":{"width":798,"height":1200},"/images/optimized/blogs/12-us-trip/l1001562.webp":{"width":1197,"height":1800},"/images/optimized/blogs/12-us-trip/l1001608.webp":{"width":1012,"height":1800},"/images/optimized/blogs/12-us-trip/l1001615.webp":{"width":1805,"height":1200},"/images/optimized/blogs/12-us-trip/l1001656.webp":{"width":1805,"height":1200},"/images/optimized/blogs/12-us-trip/l1001677.webp":{"width":1805,"height":1200},"/images/optimized/blogs/12-us-trip/l1001696.webp":{"width":1805,"height":1200},"/images/optimized/blogs/12-us-trip/l1001753.webp":{"width":1805,"height":1200},"/images/optimized/blogs/12-us-trip/l1001836.webp":{"width":1197,"height":1800},"/images/optimized/blogs/12-us-trip/l1001861.webp":{"width":1805,"height":1200},"/images/optimized/blogs/12-us-trip/l1001897.webp":{"width":1805,"height":1200},"/images/optimized/blogs/12-us-trip/l1001936.webp":{"width":1805,"height":1200},"/images/optimized/blogs/12-us-trip/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/13-chingshin/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2025_12_13_blog_launch/titlecard2.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2025_12_13_sisyphus/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2025_12_14_affinity/glitch_demo.webp":{"width":1914,"height":1200},"/images/optimized/blogs/2025_12_14_affinity/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2025_12_14_affinity/ui_portfolio.webp":{"width":1914,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf7149.webp":{"width":800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf7225.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf7261.webp":{"width":800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf7371.webp":{"width":800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf7511.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9207.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9257.webp":{"width":800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9333.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9361.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9388.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9426.webp":{"width":800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9555.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9653.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/dscf9719.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2025_12_19_xpro1/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2025_12_22_aftersun_paris_texas/aftersun_12.webp":{"width":1924,"height":1040},"/images/optimized/blogs/2025_12_22_aftersun_paris_texas/aftersun_44.webp":{"width":1924,"height":1040},"/images/optimized/blogs/2025_12_22_aftersun_paris_texas/aftersun_61.webp":{"width":1924,"height":1040},"/images/optimized/blogs/2025_12_22_aftersun_paris_texas/paris_texas_08.webp":{"width":1920,"height":1080},"/images/optimized/blogs/2025_12_22_aftersun_paris_texas/paris_texas_58.webp":{"width":1920,"height":1080},"/images/optimized/blogs/2025_12_22_aftersun_paris_texas/paris_texas_62.webp":{"width":1920,"height":1080},"/images/optimized/blogs/2025_12_22_aftersun_paris_texas/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2025_12_24_ntu_cs_special_admission/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2026_01_10_plushies/dscf9779.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2026_01_10_plushies/dscf9996.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2026_01_10_plushies/dscf9998.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2026_01_10_plushies/dscf9999.webp":{"width":1800,"height":1200},"/images/optimized/blogs/2026_01_10_plushies/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2026_02_10_synecdoche_truman/synecdoche_1.webp":{"width":1280,"height":544},"/images/optimized/blogs/2026_02_10_synecdoche_truman/synecdoche_2.webp":{"width":1280,"height":544},"/images/optimized/blogs/2026_02_10_synecdoche_truman/synecdoche_3.webp":{"width":1280,"height":544},"/images/optimized/blogs/2026_02_10_synecdoche_truman/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/blogs/2026_02_10_synecdoche_truman/truman_1.webp":{"width":1018,"height":576},"/images/optimized/blogs/2026_02_10_synecdoche_truman/truman_2.webp":{"width":1018,"height":576},"/images/optimized/blogs/2026_02_10_synecdoche_truman/truman_3.webp":{"width":1018,"height":576},"/images/optimized/blogs/2026_02_10_synecdoche_truman/truman_4.webp":{"width":1018,"height":576},"/images/optimized/blogs/9_m11d/back.webp":{"width":1800,"height":1200},"/images/optimized/blogs/9_m11d/front.webp":{"width":1800,"height":1200},"/images/optimized/blogs/9_m11d/l1000213.webp":{"width":798,"height":1200},"/images/optimized/blogs/9_m11d/l1000260.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/l1000264.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/l1000478.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/l1000667.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/l1000721.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/l1000758.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/l1000768.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/l1000927.webp":{"width":798,"height":1200},"/images/optimized/blogs/9_m11d/l1000934.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/l1000957.webp":{"width":1805,"height":1200},"/images/optimized/blogs/9_m11d/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0007-12-edited.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0018-1-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0025-2-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0031-12-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0053-6-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0054-16-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0059-7-edited.webp":{"width":1215,"height":2160},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0061-17-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0071-18-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0101-13-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0104-14-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0104-19-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2023_06_30_city_stroll/dscf0292-21-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2023_07_07_splash_of_red/dscf0007-32-edited.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2023_07_07_splash_of_red/dscf0009-25-edited.webp":{"width":2560,"height":1088},"/images/optimized/gallery/2023_07_07_splash_of_red/dscf0010-26-edited.webp":{"width":2560,"height":1088},"/images/optimized/gallery/2023_07_07_splash_of_red/dscf0016-27-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2023_07_07_splash_of_red/dscf0018-52-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_07_07_splash_of_red/dscf0050-28-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_07_07_splash_of_red/dscf0234.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_08_10_intersection/dscf0009.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0045-45-edited.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0095-46-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0097-2520edited-20edited-49-edited.webp":{"width":1440,"height":1800},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0097.webp":{"width":1440,"height":1800},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0102-50-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0103-39-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0104-40-edited.webp":{"width":1800,"height":1440},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0131-42-edited.webp":{"width":2560,"height":1088},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0258-43-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_10_05_solitary_glow/dscf0259-44-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2023_10_07_dune/4f1f0890-cde0-45b9-a935-205b7496d539-19416-000010a5e5c7f07e-edited.webp":{"width":2875,"height":1917},"/images/optimized/gallery/2023_10_07_dune/dscf7304-1-edited.webp":{"width":2560,"height":1088},"/images/optimized/gallery/2023_10_07_dune/dscf7337-2-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_10_07_dune/dscf7400-3-edited.webp":{"width":2560,"height":1088},"/images/optimized/gallery/2023_10_07_dune/dscf7403-4-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2023_10_12_lessons_from_the_light/dscf0004.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2023_11_18_at_dawn/dscf0012-3-edited.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2023_11_18_at_dawn/dscf0052-54-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_11_18_at_dawn/dscf0053-56-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_11_18_at_dawn/dscf0199-20edited-8-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_11_18_at_dawn/dscf0199.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_11_18_at_dawn/dscf7421-5-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2023_12_30_against_the_unknown/154ba3d2-bf8e-4723-b427-e4acb33b14a1-8577-000006a57cc6f050.webp":{"width":3494,"height":5241},"/images/optimized/gallery/2023_12_30_sky_above/dscf0191.webp":{"width":3840,"height":5759},"/images/optimized/gallery/2024_01_06_hehuanshan/dscf0008.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2024_01_06_hehuanshan/dscf0037.webp":{"width":1440,"height":2159},"/images/optimized/gallery/2024_01_06_hehuanshan/dscf0038.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_01_06_hehuanshan/dscf0182.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_01_06_hehuanshan/dscf0192.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_01_06_hehuanshan/dscf0206.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0004-1-edited.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0032-2-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0036-3-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0040-4-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0045-5-edited.webp":{"width":1800,"height":1440},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0012-8-edited.webp":{"width":3840,"height":2160},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0013-10-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0016-2-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0035-11-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0035-18-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0036-19-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0042-3-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0047-4-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0048-5-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0367-20-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_03_03_simple_in_a_complex_world/dscf0022-edited.webp":{"width":3840,"height":5760},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf0420-13-edited.webp":{"width":3840,"height":2560},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf0429-14-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf0441-15-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf0520-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf1482-7-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf1522-8-edited.webp":{"width":2161,"height":1440},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf1538-10-edited.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf1564-11-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_04_06_city_of_tears/dscf3385-15-edited.webp":{"width":2560,"height":1440},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0007-14-edited.webp":{"width":3840,"height":5760},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0036-20edited-2-edited.webp":{"width":2560,"height":1088},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0036edited.webp":{"width":2560,"height":1088},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0091-3-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0105-1-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf1423-4-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf1474-5-edited.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf1516.raf.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/image0113.webp":{"width":1440,"height":2160},"/images/optimized/gallery/2026-italy-city/l1000064.webp":{"width":3840,"height":2554},"/images/optimized/gallery/2026-italy-city/l1000121.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-city/l1000472.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-city/l1000474.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-city/l1000480.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-city/l1000486.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-city/l1000492.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-city/l1000502.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-city/l1000505.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-city/l1000563.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-city/l1000735.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-city/l1000758.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-city/l1000768.webp":{"width":3840,"height":2554},"/images/optimized/gallery/2026-italy-mountain/l1000164.webp":{"width":3840,"height":2554},"/images/optimized/gallery/2026-italy-mountain/l1000165.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-mountain/l1000192.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-mountain/l1000213.webp":{"width":1440,"height":2165},"/images/optimized/gallery/2026-italy-mountain/l1000217.webp":{"width":3840,"height":2554},"/images/optimized/gallery/2026-italy-mountain/l1000226.webp":{"width":1440,"height":2165},"/images/optimized/gallery/2026-italy-mountain/l1000274.webp":{"width":3840,"height":1418},"/images/optimized/gallery/2026-italy-mountain/l1000279.webp":{"width":1437,"height":2160},"/images/optimized/gallery/2026-italy-mountain/l1000288.webp":{"width":2166,"height":1440},"/images/optimized/gallery/2026-italy-mountain/l1000296.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-mountain/l1000300.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-mountain/l1000350.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-town/l1000317.webp":{"width":3840,"height":2554},"/images/optimized/gallery/2026-italy-town/l1000337.webp":{"width":2166,"height":1440},"/images/optimized/gallery/2026-italy-town/l1000343.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-town/l1000365.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-town/l1000372.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-town/l1000374.webp":{"width":1440,"height":1800},"/images/optimized/gallery/2026-italy-town/l1000403.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-italy-town/l1000419.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-italy-town/l1000813.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-us-trip/l1001482.webp":{"width":3840,"height":5775},"/images/optimized/gallery/2026-us-trip/l1001601.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-us-trip/l1001608.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-us-trip/l1001696.webp":{"width":1800,"height":1440},"/images/optimized/gallery/2026-us-trip/l1001728.webp":{"width":1437,"height":2160},"/images/optimized/gallery/2026-us-trip/l1001746.webp":{"width":1800,"height":1440},"/images/optimized/gallery/2026-us-trip/l1001775.webp":{"width":2160,"height":1440},"/images/optimized/gallery/2026-us-trip/l1001805.webp":{"width":1437,"height":2160},"/images/optimized/gallery/2026-us-trip/l1001813.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-us-trip/l1001814.webp":{"width":2165,"height":1440},"/images/optimized/gallery/2026-us-trip/l1001818.webp":{"width":1440,"height":2165},"/images/optimized/gallery/2026-us-trip/l1001832.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-us-trip/l1001863.webp":{"width":1800,"height":1440},"/images/optimized/gallery/2026-us-trip/l1001869.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-us-trip/l1001874.webp":{"width":1436,"height":2160},"/images/optimized/gallery/2026-us-trip/l1001936.webp":{"width":2165,"height":1440},"/images/optimized/projects/2024_03_18_boundless_voices/title_node_tree.webp":{"width":3200,"height":2068},"/images/optimized/projects/2024_03_18_boundless_voices/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2024_08_19_classics_reimagined/_dsf2971-81-edited.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/_dsf3005-86-edited.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/_dsf3072-90-edited.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/closing_squence_fusion-comp.webp":{"width":1966,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/closing_squence_fusion_comp.webp":{"width":1966,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/dscf1949-6-edited.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/dscf2915-24-edited.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/dscf2930-29-edited.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/dscf4477-18-edited.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/dscf4551-22-edited.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/full_timeline.webp":{"width":2000,"height":1119},"/images/optimized/projects/2024_08_19_classics_reimagined/polaroid_design.webp":{"width":1912,"height":1200},"/images/optimized/projects/2024_08_19_classics_reimagined/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2024_09_23_chingshing_ragi/rag_chinese_slides.webp":{"width":1921,"height":1200},"/images/optimized/projects/2024_09_23_chingshing_ragi/rag_english_slides.webp":{"width":1919,"height":1200},"/images/optimized/projects/2024_09_23_chingshing_ragi/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2024_10_04_zephyr/successful_purchase.webp":{"width":1813,"height":1200},"/images/optimized/projects/2024_10_04_zephyr/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2024_10_04_zephyr/zephyr_training_screen_shot.webp":{"width":1920,"height":1200},"/images/optimized/projects/2024_10_09_vrc_2813b_nova/developing_glimpse.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_10_09_vrc_2813b_nova/highstake_v1_bot.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_10_09_vrc_2813b_nova/highstake_v2_bot.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_10_09_vrc_2813b_nova/overunder_bot.webp":{"width":1800,"height":1200},"/images/optimized/projects/2024_10_09_vrc_2813b_nova/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2025_01_05_aaai_video/dscf7370.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_05_aaai_video/element_design.webp":{"width":1920,"height":1200},"/images/optimized/projects/2025_01_05_aaai_video/exporting_slices.webp":{"width":1920,"height":1200},"/images/optimized/projects/2025_01_05_aaai_video/full_timeline.webp":{"width":2000,"height":1168},"/images/optimized/projects/2025_01_05_aaai_video/keynote_animating.webp":{"width":1916,"height":1200},"/images/optimized/projects/2025_01_05_aaai_video/opening_seq_comp.webp":{"width":1916,"height":1200},"/images/optimized/projects/2025_01_05_aaai_video/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2025_01_08_powerplay/closing.webp":{"width":1919,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/credit-v2_01_01_14_21.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_01_08_powerplay/credit-v2_01_01_16_20.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_01_08_powerplay/dscf2377.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf3700.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf3706-2.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf3706.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf4045.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf4047.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf4048.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf4062.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf4064.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf4080.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/dscf4089.webp":{"width":1800,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/floating.webp":{"width":1916,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/fulltimeline.webp":{"width":2000,"height":1164},"/images/optimized/projects/2025_01_08_powerplay/opening.webp":{"width":1920,"height":1200},"/images/optimized/projects/2025_01_08_powerplay/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2025_03_08_sitcon_keynote/exporting_slices.webp":{"width":1920,"height":1200},"/images/optimized/projects/2025_03_08_sitcon_keynote/keynote_animating.webp":{"width":1916,"height":1200},"/images/optimized/projects/2025_03_08_sitcon_keynote/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2025_04_12_portfolio_design/affinity_branding.webp":{"width":1911,"height":1200},"/images/optimized/projects/2025_04_12_portfolio_design/lighthouse_benchmark.webp":{"width":1743,"height":1200},"/images/optimized/projects/2025_04_12_portfolio_design/screenshot-2026-03-19-at-10-03-05-portfolio-speed-insights-vercel.webp":{"width":1200,"height":1314},"/images/optimized/projects/2025_04_12_portfolio_design/screenshot-2026-03-19-at-10-03-18-portfolio-speed-insights-vercel.webp":{"width":1200,"height":1314},"/images/optimized/projects/2025_04_12_portfolio_design/screenshot-2026-04-17-at-12-36-27-knowledge-graph-harry-chang.webp":{"width":1922,"height":1200},"/images/optimized/projects/2025_04_12_portfolio_design/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2025_04_12_portfolio_design/vercel-dual-res.webp":{"width":1993,"height":1200},"/images/optimized/projects/2025_05_18_patch_dataset/patch_asr.webp":{"width":2000,"height":992},"/images/optimized/projects/2025_05_18_patch_dataset/patch_crosslingual.webp":{"width":2000,"height":1200},"/images/optimized/projects/2025_05_18_patch_dataset/patch_distribution.webp":{"width":2000,"height":951},"/images/optimized/projects/2025_05_18_patch_dataset/patch_human_result.webp":{"width":2000,"height":1200},"/images/optimized/projects/2025_05_18_patch_dataset/patch_main_result.webp":{"width":2000,"height":1200},"/images/optimized/projects/2025_05_18_patch_dataset/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2025_07_04_fortress_system/fortress_ablation.webp":{"width":2000,"height":809},"/images/optimized/projects/2025_07_04_fortress_system/fortress_expansion.webp":{"width":2000,"height":808},"/images/optimized/projects/2025_07_04_fortress_system/fortress_kb_projection.webp":{"width":2000,"height":1010},"/images/optimized/projects/2025_07_04_fortress_system/fortress_main_result.webp":{"width":2000,"height":1081},"/images/optimized/projects/2025_07_04_fortress_system/fortress_scalability.webp":{"width":2000,"height":809},"/images/optimized/projects/2025_07_04_fortress_system/fortress_system_diagram.webp":{"width":2000,"height":1095},"/images/optimized/projects/2025_07_04_fortress_system/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2025_08_04_debate/fhdo_2023_result.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_08_04_debate/fhdo_2024_result.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_08_04_debate/fhdo_2025_result.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_08_04_debate/fhdo_2025_speaker.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_08_04_debate/tejt_result.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_08_04_debate/tejt_speaker.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_08_04_debate/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/2025_08_04_debate/tsdc_2023_result.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_08_04_debate/tsdc_2023_speaker.webp":{"width":2000,"height":1125},"/images/optimized/projects/2025_08_04_debate/tsdc_2024_result.webp":{"width":2000,"height":1125},"/images/optimized/projects/og/og-image-blog.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image-design.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image-gallery.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image-lab.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image-manifesto.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image-projects.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image-reading.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image-resume.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image-uses.webp":{"width":1200,"height":630},"/images/optimized/projects/og/og-image.webp":{"width":1200,"height":630},"/images/optimized/projects/og/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/sitcon-2026/titlecard.webp":{"width":3000,"height":2000},"/images/optimized/projects/uses/vertical_center.webp":{"width":1200,"height":1498},"/images/optimized/projects/uses/vertical_left.webp":{"width":1200,"height":1498},"/images/optimized/projects/uses/vertical_right.webp":{"width":1200,"height":1498}}
+{
+  "/images/optimized/blogs/10-lego-mount/l1001284.webp": {
+    "width": 1804,
+    "height": 1200
+  },
+  "/images/optimized/blogs/10-lego-mount/l1001285.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/10-lego-mount/l1001286.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/10-lego-mount/l1001288.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/10-lego-mount/l1001290.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/10-lego-mount/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/11-portfolio/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/12-us-trip/l1001460.webp": {
+    "width": 798,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/l1001562.webp": {
+    "width": 1197,
+    "height": 1800
+  },
+  "/images/optimized/blogs/12-us-trip/l1001608.webp": {
+    "width": 1012,
+    "height": 1800
+  },
+  "/images/optimized/blogs/12-us-trip/l1001615.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/l1001656.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/l1001677.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/l1001696.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/l1001753.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/l1001836.webp": {
+    "width": 1197,
+    "height": 1800
+  },
+  "/images/optimized/blogs/12-us-trip/l1001861.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/l1001897.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/l1001936.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/12-us-trip/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/13-chingshin/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2025_12_13_blog_launch/titlecard2.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2025_12_13_sisyphus/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2025_12_14_affinity/glitch_demo.webp": {
+    "width": 1914,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_14_affinity/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2025_12_14_affinity/ui_portfolio.webp": {
+    "width": 1914,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf7149.webp": {
+    "width": 800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf7225.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf7261.webp": {
+    "width": 800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf7371.webp": {
+    "width": 800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf7511.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9207.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9257.webp": {
+    "width": 800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9333.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9361.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9388.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9426.webp": {
+    "width": 800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9555.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9653.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/dscf9719.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2025_12_19_xpro1/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2025_12_22_aftersun_paris_texas/aftersun_12.webp": {
+    "width": 1924,
+    "height": 1040
+  },
+  "/images/optimized/blogs/2025_12_22_aftersun_paris_texas/aftersun_44.webp": {
+    "width": 1924,
+    "height": 1040
+  },
+  "/images/optimized/blogs/2025_12_22_aftersun_paris_texas/aftersun_61.webp": {
+    "width": 1924,
+    "height": 1040
+  },
+  "/images/optimized/blogs/2025_12_22_aftersun_paris_texas/paris_texas_08.webp": {
+    "width": 1920,
+    "height": 1080
+  },
+  "/images/optimized/blogs/2025_12_22_aftersun_paris_texas/paris_texas_58.webp": {
+    "width": 1920,
+    "height": 1080
+  },
+  "/images/optimized/blogs/2025_12_22_aftersun_paris_texas/paris_texas_62.webp": {
+    "width": 1920,
+    "height": 1080
+  },
+  "/images/optimized/blogs/2025_12_22_aftersun_paris_texas/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2025_12_24_ntu_cs_special_admission/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2026_01_10_plushies/dscf9779.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2026_01_10_plushies/dscf9996.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2026_01_10_plushies/dscf9998.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2026_01_10_plushies/dscf9999.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/2026_01_10_plushies/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2026_02_10_synecdoche_truman/synecdoche_1.webp": {
+    "width": 1280,
+    "height": 544
+  },
+  "/images/optimized/blogs/2026_02_10_synecdoche_truman/synecdoche_2.webp": {
+    "width": 1280,
+    "height": 544
+  },
+  "/images/optimized/blogs/2026_02_10_synecdoche_truman/synecdoche_3.webp": {
+    "width": 1280,
+    "height": 544
+  },
+  "/images/optimized/blogs/2026_02_10_synecdoche_truman/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/blogs/2026_02_10_synecdoche_truman/truman_1.webp": {
+    "width": 1018,
+    "height": 576
+  },
+  "/images/optimized/blogs/2026_02_10_synecdoche_truman/truman_2.webp": {
+    "width": 1018,
+    "height": 576
+  },
+  "/images/optimized/blogs/2026_02_10_synecdoche_truman/truman_3.webp": {
+    "width": 1018,
+    "height": 576
+  },
+  "/images/optimized/blogs/2026_02_10_synecdoche_truman/truman_4.webp": {
+    "width": 1018,
+    "height": 576
+  },
+  "/images/optimized/blogs/9_m11d/back.webp": { "width": 1800, "height": 1200 },
+  "/images/optimized/blogs/9_m11d/front.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000213.webp": {
+    "width": 798,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000260.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000264.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000478.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000667.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000721.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000758.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000768.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000927.webp": {
+    "width": 798,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000934.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/l1000957.webp": {
+    "width": 1805,
+    "height": 1200
+  },
+  "/images/optimized/blogs/9_m11d/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0007-12-edited.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0018-1-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0025-2-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0031-12-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0053-6-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0054-16-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0059-7-edited.webp": {
+    "width": 1215,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0061-17-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0071-18-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0101-13-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0104-14-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0104-19-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2023_06_30_city_stroll/dscf0292-21-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2023_07_07_splash_of_red/dscf0007-32-edited.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2023_07_07_splash_of_red/dscf0009-25-edited.webp": {
+    "width": 2560,
+    "height": 1088
+  },
+  "/images/optimized/gallery/2023_07_07_splash_of_red/dscf0010-26-edited.webp": {
+    "width": 2560,
+    "height": 1088
+  },
+  "/images/optimized/gallery/2023_07_07_splash_of_red/dscf0016-27-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2023_07_07_splash_of_red/dscf0018-52-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_07_07_splash_of_red/dscf0050-28-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_07_07_splash_of_red/dscf0234.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_08_10_intersection/dscf0009.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0045-45-edited.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0095-46-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0097-2520edited-20edited-49-edited.webp": {
+    "width": 1440,
+    "height": 1800
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0097.webp": {
+    "width": 1440,
+    "height": 1800
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0102-50-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0103-39-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0104-40-edited.webp": {
+    "width": 1800,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0131-42-edited.webp": {
+    "width": 2560,
+    "height": 1088
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0258-43-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_10_05_solitary_glow/dscf0259-44-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2023_10_07_dune/4f1f0890-cde0-45b9-a935-205b7496d539-19416-000010a5e5c7f07e-edited.webp": {
+    "width": 2875,
+    "height": 1917
+  },
+  "/images/optimized/gallery/2023_10_07_dune/dscf7304-1-edited.webp": {
+    "width": 2560,
+    "height": 1088
+  },
+  "/images/optimized/gallery/2023_10_07_dune/dscf7337-2-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_10_07_dune/dscf7400-3-edited.webp": {
+    "width": 2560,
+    "height": 1088
+  },
+  "/images/optimized/gallery/2023_10_07_dune/dscf7403-4-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2023_10_12_lessons_from_the_light/dscf0004.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2023_11_18_at_dawn/dscf0012-3-edited.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2023_11_18_at_dawn/dscf0052-54-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_11_18_at_dawn/dscf0053-56-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_11_18_at_dawn/dscf0199-20edited-8-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_11_18_at_dawn/dscf0199.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_11_18_at_dawn/dscf7421-5-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2023_12_30_against_the_unknown/154ba3d2-bf8e-4723-b427-e4acb33b14a1-8577-000006a57cc6f050.webp": {
+    "width": 3494,
+    "height": 5241
+  },
+  "/images/optimized/gallery/2023_12_30_sky_above/dscf0191.webp": {
+    "width": 3840,
+    "height": 5759
+  },
+  "/images/optimized/gallery/2024_01_06_hehuanshan/dscf0008.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2024_01_06_hehuanshan/dscf0037.webp": {
+    "width": 1440,
+    "height": 2159
+  },
+  "/images/optimized/gallery/2024_01_06_hehuanshan/dscf0038.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_01_06_hehuanshan/dscf0182.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_01_06_hehuanshan/dscf0192.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_01_06_hehuanshan/dscf0206.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0004-1-edited.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0032-2-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0036-3-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0040-4-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_09_mortal_sparks/dscf0045-5-edited.webp": {
+    "width": 1800,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0012-8-edited.webp": {
+    "width": 3840,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0013-10-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0016-2-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0035-11-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0035-18-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0036-19-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0042-3-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0047-4-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0048-5-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_02_14_go_where_you_feel_most_alive/dscf0367-20-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_03_03_simple_in_a_complex_world/dscf0022-edited.webp": {
+    "width": 3840,
+    "height": 5760
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf0420-13-edited.webp": {
+    "width": 3840,
+    "height": 2560
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf0429-14-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf0441-15-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf0520-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf1482-7-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf1522-8-edited.webp": {
+    "width": 2161,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf1538-10-edited.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf1564-11-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_04_06_city_of_tears/dscf3385-15-edited.webp": {
+    "width": 2560,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0007-14-edited.webp": {
+    "width": 3840,
+    "height": 5760
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0036-20edited-2-edited.webp": {
+    "width": 2560,
+    "height": 1088
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0036edited.webp": {
+    "width": 2560,
+    "height": 1088
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0091-3-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf0105-1-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf1423-4-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf1474-5-edited.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/dscf1516.raf.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2024_07_03_simple_in_a_complex_word/image0113.webp": {
+    "width": 1440,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000064.webp": {
+    "width": 3840,
+    "height": 2554
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000121.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000472.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000474.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000480.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000486.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000492.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000502.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000505.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000563.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000735.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000758.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-city/l1000768.webp": {
+    "width": 3840,
+    "height": 2554
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000164.webp": {
+    "width": 3840,
+    "height": 2554
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000165.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000192.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000213.webp": {
+    "width": 1440,
+    "height": 2165
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000217.webp": {
+    "width": 3840,
+    "height": 2554
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000226.webp": {
+    "width": 1440,
+    "height": 2165
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000274.webp": {
+    "width": 3840,
+    "height": 1418
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000279.webp": {
+    "width": 1437,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000288.webp": {
+    "width": 2166,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000296.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000300.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-mountain/l1000350.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000317.webp": {
+    "width": 3840,
+    "height": 2554
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000337.webp": {
+    "width": 2166,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000343.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000365.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000372.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000374.webp": {
+    "width": 1440,
+    "height": 1800
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000403.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000419.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-italy-town/l1000813.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001482.webp": {
+    "width": 3840,
+    "height": 5775
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001601.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001608.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001696.webp": {
+    "width": 1800,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001728.webp": {
+    "width": 1437,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001746.webp": {
+    "width": 1800,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001775.webp": {
+    "width": 2160,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001805.webp": {
+    "width": 1437,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001813.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001814.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001818.webp": {
+    "width": 1440,
+    "height": 2165
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001832.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001863.webp": {
+    "width": 1800,
+    "height": 1440
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001869.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001874.webp": {
+    "width": 1436,
+    "height": 2160
+  },
+  "/images/optimized/gallery/2026-us-trip/l1001936.webp": {
+    "width": 2165,
+    "height": 1440
+  },
+  "/images/optimized/projects/2024_03_18_boundless_voices/title_node_tree.webp": {
+    "width": 3200,
+    "height": 2068
+  },
+  "/images/optimized/projects/2024_03_18_boundless_voices/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/_dsf2971-81-edited.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/_dsf3005-86-edited.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/_dsf3072-90-edited.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/closing_squence_fusion-comp.webp": {
+    "width": 1966,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/closing_squence_fusion_comp.webp": {
+    "width": 1966,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/dscf1949-6-edited.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/dscf2915-24-edited.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/dscf2930-29-edited.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/dscf4477-18-edited.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/dscf4551-22-edited.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/full_timeline.webp": {
+    "width": 2000,
+    "height": 1119
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/polaroid_design.webp": {
+    "width": 1912,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_08_19_classics_reimagined/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2024_09_23_chingshing_ragi/rag_chinese_slides.webp": {
+    "width": 1921,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_09_23_chingshing_ragi/rag_english_slides.webp": {
+    "width": 1919,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_09_23_chingshing_ragi/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2024_10_04_zephyr/successful_purchase.webp": {
+    "width": 1813,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_10_04_zephyr/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2024_10_04_zephyr/zephyr_training_screen_shot.webp": {
+    "width": 1920,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_10_09_vrc_2813b_nova/developing_glimpse.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_10_09_vrc_2813b_nova/highstake_v1_bot.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_10_09_vrc_2813b_nova/highstake_v2_bot.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_10_09_vrc_2813b_nova/overunder_bot.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2024_10_09_vrc_2813b_nova/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2025_01_05_aaai_video/dscf7370.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_05_aaai_video/element_design.webp": {
+    "width": 1920,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_05_aaai_video/exporting_slices.webp": {
+    "width": 1920,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_05_aaai_video/full_timeline.webp": {
+    "width": 2000,
+    "height": 1168
+  },
+  "/images/optimized/projects/2025_01_05_aaai_video/keynote_animating.webp": {
+    "width": 1916,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_05_aaai_video/opening_seq_comp.webp": {
+    "width": 1916,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_05_aaai_video/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/closing.webp": {
+    "width": 1919,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/credit-v2_01_01_14_21.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/credit-v2_01_01_16_20.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf2377.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf3700.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf3706-2.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf3706.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf4045.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf4047.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf4048.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf4062.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf4064.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf4080.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/dscf4089.webp": {
+    "width": 1800,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/floating.webp": {
+    "width": 1916,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/fulltimeline.webp": {
+    "width": 2000,
+    "height": 1164
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/opening.webp": {
+    "width": 1920,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_01_08_powerplay/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2025_03_08_sitcon_keynote/exporting_slices.webp": {
+    "width": 1920,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_03_08_sitcon_keynote/keynote_animating.webp": {
+    "width": 1916,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_03_08_sitcon_keynote/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2025_04_12_portfolio_design/affinity_branding.webp": {
+    "width": 1911,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_04_12_portfolio_design/lighthouse_benchmark.webp": {
+    "width": 1743,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_04_12_portfolio_design/screenshot-2026-03-19-at-10-03-05-portfolio-speed-insights-vercel.webp": {
+    "width": 1200,
+    "height": 1314
+  },
+  "/images/optimized/projects/2025_04_12_portfolio_design/screenshot-2026-03-19-at-10-03-18-portfolio-speed-insights-vercel.webp": {
+    "width": 1200,
+    "height": 1314
+  },
+  "/images/optimized/projects/2025_04_12_portfolio_design/screenshot-2026-04-17-at-12-36-27-knowledge-graph-harry-chang.webp": {
+    "width": 1922,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_04_12_portfolio_design/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2025_04_12_portfolio_design/vercel-dual-res.webp": {
+    "width": 1993,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_05_18_patch_dataset/patch_asr.webp": {
+    "width": 2000,
+    "height": 992
+  },
+  "/images/optimized/projects/2025_05_18_patch_dataset/patch_crosslingual.webp": {
+    "width": 2000,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_05_18_patch_dataset/patch_distribution.webp": {
+    "width": 2000,
+    "height": 951
+  },
+  "/images/optimized/projects/2025_05_18_patch_dataset/patch_human_result.webp": {
+    "width": 2000,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_05_18_patch_dataset/patch_main_result.webp": {
+    "width": 2000,
+    "height": 1200
+  },
+  "/images/optimized/projects/2025_05_18_patch_dataset/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2025_07_04_fortress_system/fortress_ablation.webp": {
+    "width": 2000,
+    "height": 809
+  },
+  "/images/optimized/projects/2025_07_04_fortress_system/fortress_expansion.webp": {
+    "width": 2000,
+    "height": 808
+  },
+  "/images/optimized/projects/2025_07_04_fortress_system/fortress_kb_projection.webp": {
+    "width": 2000,
+    "height": 1010
+  },
+  "/images/optimized/projects/2025_07_04_fortress_system/fortress_main_result.webp": {
+    "width": 2000,
+    "height": 1081
+  },
+  "/images/optimized/projects/2025_07_04_fortress_system/fortress_scalability.webp": {
+    "width": 2000,
+    "height": 809
+  },
+  "/images/optimized/projects/2025_07_04_fortress_system/fortress_system_diagram.webp": {
+    "width": 2000,
+    "height": 1095
+  },
+  "/images/optimized/projects/2025_07_04_fortress_system/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2025_08_04_debate/fhdo_2023_result.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_08_04_debate/fhdo_2024_result.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_08_04_debate/fhdo_2025_result.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_08_04_debate/fhdo_2025_speaker.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_08_04_debate/tejt_result.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_08_04_debate/tejt_speaker.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_08_04_debate/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/2025_08_04_debate/tsdc_2023_result.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_08_04_debate/tsdc_2023_speaker.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/2025_08_04_debate/tsdc_2024_result.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/menghua/lyrics-affinity-comp.webp": {
+    "width": 1911,
+    "height": 1200
+  },
+  "/images/optimized/projects/menghua/matchcut-empty.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/menghua/matchcut-full.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/menghua/screen-comp-fusion.webp": {
+    "width": 1914,
+    "height": 1200
+  },
+  "/images/optimized/projects/menghua/still-past.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/menghua/still-present.webp": {
+    "width": 2000,
+    "height": 1125
+  },
+  "/images/optimized/projects/menghua/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/og/og-image-blog.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image-design.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image-gallery.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image-lab.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image-manifesto.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image-projects.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image-reading.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image-resume.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image-uses.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/og-image.webp": {
+    "width": 1200,
+    "height": 630
+  },
+  "/images/optimized/projects/og/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/sitcon-2026/titlecard.webp": {
+    "width": 3000,
+    "height": 2000
+  },
+  "/images/optimized/projects/uses/vertical_center.webp": {
+    "width": 1200,
+    "height": 1498
+  },
+  "/images/optimized/projects/uses/vertical_left.webp": {
+    "width": 1200,
+    "height": 1498
+  },
+  "/images/optimized/projects/uses/vertical_right.webp": {
+    "width": 1200,
+    "height": 1498
+  }
+}

--- a/apps/harrychang-me/content/generated/section-summaries.json
+++ b/apps/harrychang-me/content/generated/section-summaries.json
@@ -1387,5 +1387,17 @@
       "致謝": "幕前幕後核心團隊與書法協力"
     },
     "tldr": "作者一個月內完成靜心畢業歌 MV 攝影、剪輯與後期"
+  },
+  "locale/privacy/en": {
+    "title": "Privacy",
+    "locale": "en",
+    "sections": {},
+    "tldr": "How this site handles cookies, analytics, and your data"
+  },
+  "locale/privacy/zh-TW": {
+    "title": "隱私權政策",
+    "locale": "zh-TW",
+    "sections": {},
+    "tldr": "本站如何處理 Cookie、分析工具與你的資料"
   }
 }

--- a/apps/harrychang-me/public/locales/en/common.json
+++ b/apps/harrychang-me/public/locales/en/common.json
@@ -13,7 +13,8 @@
     "links": "Links",
     "design": "Design System",
     "cv": "Résumé",
-    "graph": "Site Graph"
+    "graph": "Site Graph",
+    "privacy": "Privacy"
   },
   "footer": {
     "guestbook": "Guestbook",
@@ -176,7 +177,8 @@
     "design": "Design System",
     "graph": "Knowledge Graph",
     "linktree": "Links",
-    "source": "Source Code"
+    "source": "Source Code",
+    "privacy": "Privacy"
   },
   "links": {
     "hero": "Code. Camera. Curiosity."
@@ -213,7 +215,8 @@
     "telegram": "Encrypted chats welcome — find me @harrychangtw",
     "graph": "Explore this site as an interactive knowledge graph",
     "source": "View the monorepo source code and README on GitHub",
-    "linktree": "All my links, gathered in one place"
+    "linktree": "All my links, gathered in one place",
+    "privacy": "How this site handles your data"
   },
   "letterGlitch": {
     "line1": "I was never taught to create—",
@@ -229,6 +232,33 @@
   },
   "notification": {
     "pageNotFound": "Page not found. Redirected to home."
+  },
+  "privacy": {
+    "title": "Privacy",
+    "overview": {
+      "title": "Overview",
+      "body": "This is a personal portfolio site. It does not sell data, serve ads, or require an account. Data collection is minimal and exists solely to improve the browsing experience."
+    },
+    "cookies": {
+      "title": "Cookies",
+      "body": "This site sets a small number of functional cookies. A <strong>theme</strong> cookie persists your light/dark preference across the main site and lab subdomain. A <strong>language</strong> cookie remembers your selection between English and Traditional Chinese. No tracking cookies are set without your knowledge."
+    },
+    "analytics": {
+      "title": "Analytics",
+      "body": "<strong>PostHog</strong> collects anonymous page views, session duration, and general device info. No IP addresses are stored. <strong>Vercel Analytics</strong> measures Core Web Vitals for performance monitoring. No cookies, no personal data. Neither service collects personally identifiable information."
+    },
+    "guestbook": {
+      "title": "Guestbook",
+      "body": "Messages submitted through the guestbook are forwarded to a private <strong>Discord webhook</strong> for review. They are not displayed publicly. No account or personal information is required. All submissions are anonymous."
+    },
+    "thirdParty": {
+      "title": "Third-Party Services",
+      "body": "The <strong>Now Playing</strong> widget fetches the current track from Spotify's API. No visitor data is sent to Spotify. Fonts are fetched at build time and served locally. No third-party tracking scripts beyond the analytics listed above are loaded. The entire source code is <strong>open-source</strong> and available for inspection on GitHub."
+    },
+    "rights": {
+      "title": "Your Rights",
+      "body": "You can clear all cookies at any time through your browser settings. For questions about your data or to request removal of a guestbook message, contact <a href=\"mailto:chiwei@harrychang.me\">chiwei@harrychang.me</a>."
+    }
   },
   "lab": {
     "capsule": "Open · Closing September 2026",

--- a/apps/harrychang-me/public/locales/zh-TW/common.json
+++ b/apps/harrychang-me/public/locales/zh-TW/common.json
@@ -13,7 +13,8 @@
     "links": "連結",
     "design": "設計系統",
     "cv": "履歷",
-    "graph": "網站圖譜"
+    "graph": "網站圖譜",
+    "privacy": "隱私權政策"
   },
   "footer": {
     "guestbook": "匿名留言板",
@@ -176,7 +177,8 @@
     "design": "設計系統",
     "graph": "知識圖譜",
     "linktree": "連結",
-    "source": "網站原始碼"
+    "source": "網站原始碼",
+    "privacy": "隱私權政策"
   },
   "links": {
     "hero": "Code. Camera. Curiosity."
@@ -213,7 +215,8 @@
     "telegram": "加密訊息歡迎 — @harrychangtw",
     "graph": "以互動知識圖譜的方式探索本站",
     "source": "在 GitHub 上探索本站的架構",
-    "linktree": "所有連結，集中於此"
+    "linktree": "所有連結，集中於此",
+    "privacy": "本站如何處理你的資料"
   },
   "letterGlitch": {
     "line1": "我 從 未 被 教 會 創 造 ——",
@@ -229,6 +232,33 @@
   },
   "notification": {
     "pageNotFound": "頁面未找到，已重新導向至首頁。"
+  },
+  "privacy": {
+    "title": "隱私權政策",
+    "overview": {
+      "title": "概述",
+      "body": "這是一個個人作品集網站，不會銷售資料、投放廣告或要求建立帳號。資料蒐集極少，僅用於改善瀏覽體驗。"
+    },
+    "cookies": {
+      "title": "Cookie",
+      "body": "本站設定少量功能性 Cookie。<strong>主題</strong> Cookie 儲存你的淺色/深色模式偏好，在主站與 Lab 子網域間同步。<strong>語言</strong> Cookie 記住你在英文與繁體中文之間的選擇。不會在未告知的情況下設定追蹤 Cookie。"
+    },
+    "analytics": {
+      "title": "分析工具",
+      "body": "<strong>PostHog</strong> 蒐集匿名頁面瀏覽、工作階段時長及一般裝置資訊，不儲存 IP 位址。<strong>Vercel Analytics</strong> 測量 Core Web Vitals 以監控效能，無 Cookie，無個人資料。兩者皆不蒐集個人可識別資訊。"
+    },
+    "guestbook": {
+      "title": "留言板",
+      "body": "透過留言板提交的訊息會轉發至私人 <strong>Discord webhook</strong> 供審閱，不會公開顯示。不需要帳號或個人資訊，所有提交皆為匿名。"
+    },
+    "thirdParty": {
+      "title": "第三方服務",
+      "body": "<strong>正在播放</strong>小工具從 Spotify API 取得目前播放的曲目，不會將訪客資料傳送至 Spotify。字型在建置時取得後於本地提供。除上述分析服務外，不會載入任何第三方追蹤腳本。完整原始碼皆為<strong>開源</strong>，可於 GitHub 上查閱。"
+    },
+    "rights": {
+      "title": "你的權利",
+      "body": "你可以隨時透過瀏覽器設定清除所有 Cookie。如有關於資料的疑問或希望刪除留言板訊息，請聯繫 <a href=\"mailto:chiwei@harrychang.me\">chiwei@harrychang.me</a>。"
+    }
   },
   "lab": {
     "capsule": "開放申請中 · 九月前限定",

--- a/apps/harrychang-me/public/sitemap-index.xml
+++ b/apps/harrychang-me/public/sitemap-index.xml
@@ -2,10 +2,10 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://www.harrychang.me/sitemap.xml</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-06-09</lastmod>
   </sitemap>
   <sitemap>
     <loc>https://lab.harrychang.me/sitemap-lab.xml</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-06-09</lastmod>
   </sitemap>
 </sitemapindex>

--- a/apps/harrychang-me/public/sitemap-lab.xml
+++ b/apps/harrychang-me/public/sitemap-lab.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://lab.harrychang.me</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1</priority>
   </url>

--- a/apps/harrychang-me/public/sitemap.xml
+++ b/apps/harrychang-me/public/sitemap.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://www.harrychang.me</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me"/>
@@ -11,7 +11,7 @@
   </url>
   <url>
     <loc>https://www.harrychang.me/projects</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/projects"/>
@@ -19,7 +19,7 @@
   </url>
   <url>
     <loc>https://www.harrychang.me/gallery</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/gallery"/>
@@ -27,7 +27,7 @@
   </url>
   <url>
     <loc>https://www.harrychang.me/blog</loc>
-    <lastmod>2026-05-06</lastmod>
+    <lastmod>2026-06-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/blog"/>
@@ -224,6 +224,22 @@
     <priority>0.6</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/projects/2025_10_12_fortress"/>
     <xhtml:link rel="alternate" hreflang="zh-TW" href="https://www.harrychang.me/projects/2025_10_12_fortress_zh-tw"/>
+  </url>
+  <url>
+    <loc>https://www.harrychang.me/projects/menghua-graduation-mv</loc>
+    <lastmod>2026-06-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/projects/menghua-graduation-mv"/>
+    <xhtml:link rel="alternate" hreflang="zh-TW" href="https://www.harrychang.me/projects/menghua-graduation-mv_zh-tw"/>
+  </url>
+  <url>
+    <loc>https://www.harrychang.me/projects/menghua-graduation-mv_zh-tw</loc>
+    <lastmod>2026-06-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.harrychang.me/projects/menghua-graduation-mv"/>
+    <xhtml:link rel="alternate" hreflang="zh-TW" href="https://www.harrychang.me/projects/menghua-graduation-mv_zh-tw"/>
   </url>
   <url>
     <loc>https://www.harrychang.me/projects/sitcon-2026</loc>

--- a/apps/harrychang-me/scripts/build_graph.py
+++ b/apps/harrychang-me/scripts/build_graph.py
@@ -1399,6 +1399,7 @@ def main():
                     if isinstance(_common.get("readingList"), dict)
                     else "Reading List",
                 "design": _header.get("design", "Design System"),
+                "privacy": _header.get("privacy", "Privacy"),
                 "root": "首頁" if _loc == "zh-TW" else "Home",
             }
         else:
@@ -1524,6 +1525,27 @@ def main():
             "sourceSlug": "design",
             "locale": locale,
             "url": f"{BASE_URL}/design",
+            "date": None,
+            "tags": [],
+            "heading": None,
+            "imageUrl": None,
+            "parentId": None,
+            "mediaSource": None,
+        })
+
+    # --- Privacy hub (no existing locale nodes, standalone) ---
+    for locale in ("en", "zh-TW"):
+        hub_id = f"hub-privacy-{locale}"
+        title = _hub_title("privacy", locale)
+        hub_nodes.append({
+            "id": hub_id,
+            "nodeType": "hub",
+            "title": title,
+            "snippet": title,
+            "sourceType": "locale",
+            "sourceSlug": "privacy",
+            "locale": locale,
+            "url": f"{BASE_URL}/privacy",
             "date": None,
             "tags": [],
             "heading": None,

--- a/packages/lib/contexts/language-context.tsx
+++ b/packages/lib/contexts/language-context.tsx
@@ -39,14 +39,14 @@ const parseHtmlToReact = (
     children: React.ReactNode;
   }>,
 ): React.ReactNode => {
-  const linkRegex = /<a\s+href="([^"]*)"[^>]*>([^<]*)<\/a>/g;
+  const tagRegex =
+    /<a\s+href="([^"]*)"[^>]*>([^<]*)<\/a>|<strong>([^<]*)<\/strong>/g;
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
   let match;
   let key = 0;
 
-  while ((match = linkRegex.exec(htmlString)) !== null) {
-    // Add text before the link
+  while ((match = tagRegex.exec(htmlString)) !== null) {
     if (match.index > lastIndex) {
       const textBefore = htmlString.substring(lastIndex, match.index);
       if (textBefore) {
@@ -54,47 +54,54 @@ const parseHtmlToReact = (
       }
     }
 
-    const href = match[1];
-    const linkText = match[2];
-    const isExternal = /^https?:\/\//.test(href);
-    const isHash = href.startsWith("#");
-
-    if (isExternal || isHash) {
+    if (match[3] !== undefined) {
       parts.push(
-        <a
-          key={`link-${key++}`}
-          href={href}
-          {...(isExternal
-            ? { target: "_blank", rel: "noopener noreferrer" }
-            : {})}
-          className="link-external"
-        >
-          {linkText}
-        </a>,
-      );
-    } else if (InternalLink) {
-      const resolvedHref = href.startsWith("/") ? href : `/${href}`;
-      parts.push(
-        <InternalLink
-          key={`link-${key++}`}
-          href={resolvedHref}
-          className="link-external"
-        >
-          {linkText}
-        </InternalLink>,
+        <strong key={`strong-${key++}`} className="font-medium">
+          {match[3]}
+        </strong>,
       );
     } else {
-      parts.push(
-        <a key={`link-${key++}`} href={href} className="link-external">
-          {linkText}
-        </a>,
-      );
+      const href = match[1];
+      const linkText = match[2];
+      const isExternal = /^https?:\/\//.test(href);
+      const isHash = href.startsWith("#");
+
+      if (isExternal || isHash) {
+        parts.push(
+          <a
+            key={`link-${key++}`}
+            href={href}
+            {...(isExternal
+              ? { target: "_blank", rel: "noopener noreferrer" }
+              : {})}
+            className="link-external"
+          >
+            {linkText}
+          </a>,
+        );
+      } else if (InternalLink) {
+        const resolvedHref = href.startsWith("/") ? href : `/${href}`;
+        parts.push(
+          <InternalLink
+            key={`link-${key++}`}
+            href={resolvedHref}
+            className="link-external"
+          >
+            {linkText}
+          </InternalLink>,
+        );
+      } else {
+        parts.push(
+          <a key={`link-${key++}`} href={href} className="link-external">
+            {linkText}
+          </a>,
+        );
+      }
     }
 
-    lastIndex = linkRegex.lastIndex;
+    lastIndex = tagRegex.lastIndex;
   }
 
-  // Add remaining text after the last link
   if (lastIndex < htmlString.length) {
     const remainingText = htmlString.substring(lastIndex);
     if (remainingText) {
@@ -102,7 +109,6 @@ const parseHtmlToReact = (
     }
   }
 
-  // If no links were found, return the original string
   return parts.length > 0 ? <>{parts}</> : htmlString;
 };
 


### PR DESCRIPTION
## Summary
- Add `/privacy` route with a lightweight privacy policy page covering cookies, analytics (PostHog, Vercel), guestbook (Discord webhook), third-party services, and user rights
- Full bilingual support (EN + zh-TW) using existing i18n system with `tHtml` for inline `<strong>` and `<a>` tag rendering
- Extend shared `parseHtmlToReact` in `language-context.tsx` and `updates-section.tsx` to support `<strong>` tags
- Integrate into footer (Site Map), header (special pages), sitemap, and knowledge graph (`build_graph.py` hub node + section-summaries TL;DR)

## Test plan
- [ ] Visit `/privacy` in both light and dark mode
- [ ] Toggle language between EN and zh-TW on the privacy page
- [ ] Verify bold terms (PostHog, Vercel Analytics, Discord webhook, etc.) render correctly
- [ ] Verify email link in "Your Rights" section opens mailto
- [ ] Confirm "Privacy" appears in footer Site Map section
- [ ] Confirm header shows "Privacy" / "隱私權政策" when on the page
- [ ] Verify `/privacy` appears in sitemap.xml
- [ ] Run `build_graph.py` and confirm `hub-privacy-en` / `hub-privacy-zh-TW` nodes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Privacy Policy page accessible from header, footer, and resources navigation
  * Privacy Policy now available in English and Traditional Chinese
  * Details site data practices including cookies, analytics, and user rights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->